### PR TITLE
feat: add experimental job logger

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,10 @@
 import { julr } from '@julr/tooling-configs/eslint'
 
 export default await julr({
+  typescript: {
+    forceDecorators: true,
+  },
+
   rules: {
     '@typescript-eslint/no-unused-expressions': 'off',
     'jsonc/no-useless-escape': 'off',

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -15,14 +15,12 @@ export type Config<KnownQueues extends Record<string, QueueConfig>> = {
   connection: BullConnectionOptions
   defaultQueue: keyof KnownQueues
   queues: KnownQueues
-  experimental?: {
-    /**
-     * Multi logger allows you to use the AdonisJS logger as usual within your jobs,
-     * but logs will be sent to both your configured Pino destinations (console, files, etc.)
-     * AND to the BullMQ job logs (visible in the queue dashboard).
-     */
-    multiLogger?: { enabled?: boolean }
-  }
+  /**
+   * Multi logger allows you to use the AdonisJS logger as usual within your jobs,
+   * but logs will be sent to both your configured Pino destinations (console, files, etc.)
+   * AND to the BullMQ job logs (visible in the queue dashboard).
+   */
+  multiLogger?: { enabled?: boolean }
 }
 
 export type QueueConfig = Omit<BullQueueOptions, 'connection' | 'skipVersionCheck'> & {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -15,6 +15,14 @@ export type Config<KnownQueues extends Record<string, QueueConfig>> = {
   connection: BullConnectionOptions
   defaultQueue: keyof KnownQueues
   queues: KnownQueues
+  experimental?: {
+    /**
+     * Multi logger allows you to use the AdonisJS logger as usual within your jobs,
+     * but logs will be sent to both your configured Pino destinations (console, files, etc.)
+     * AND to the BullMQ job logs (visible in the queue dashboard).
+     */
+    multiLogger?: { enabled?: boolean }
+  }
 }
 
 export type QueueConfig = Omit<BullQueueOptions, 'connection' | 'skipVersionCheck'> & {

--- a/packages/core/src/worker/job_logger.ts
+++ b/packages/core/src/worker/job_logger.ts
@@ -63,6 +63,7 @@ export class JobLogger extends Logger<any> {
    * Generic log method that handles both Pino and BullMQ logging
    */
   #log(level: string, mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    const timestamp = new Date().toISOString()
     const pinoLogMethod = this.#adonisLogger[level as keyof Logger] as (...args: any[]) => void
 
     /**
@@ -73,7 +74,7 @@ export class JobLogger extends Logger<any> {
 
       if (!this.#logToBullMQ) return
       const prefix = level.toUpperCase()
-      this.#bullJob.log(`${prefix}: ${mergingObjectOrMessage}`)
+      this.#bullJob.log(`[${timestamp}] ${prefix}: ${mergingObjectOrMessage}`)
 
       return
     }
@@ -85,7 +86,9 @@ export class JobLogger extends Logger<any> {
 
     if (!this.#logToBullMQ) return
     const prefix = level.toUpperCase()
-    this.#bullJob.log(`${prefix}: ${this.#formatMessage(message || '', mergingObjectOrMessage)}`)
+    this.#bullJob.log(
+      `[${timestamp}] ${prefix}: ${this.#formatMessage(message || '', mergingObjectOrMessage)}`,
+    )
   }
 
   info(mergingObject: any, message?: string, ...values: any[]): void

--- a/packages/core/src/worker/job_logger.ts
+++ b/packages/core/src/worker/job_logger.ts
@@ -1,0 +1,138 @@
+import { Logger } from '@adonisjs/core/logger'
+
+import type { BullJob } from '../types/index.js'
+
+/**
+ * Combined logger that sends logs to both Pino (AdonisJS) and BullMQ
+ */
+export class JobLogger extends Logger<any> {
+  #adonisLogger: Logger
+  #bullJob: BullJob
+  #logToBullMQ: boolean
+
+  constructor(options: {
+    adonisLogger: Logger
+    bullJob: BullJob
+    options: { logToBullMQ: boolean }
+  }) {
+    super({}, options.adonisLogger.pino)
+
+    this.#adonisLogger = options.adonisLogger
+    this.#bullJob = options.bullJob
+    this.#logToBullMQ = options.options.logToBullMQ
+  }
+
+  /**
+   * Helper to serialize complex objects to string for BullMQ
+   */
+  #serialize(data: any): string {
+    if (typeof data === 'string') return data
+    if (data instanceof Error) return `${data.name}: ${data.message}\n${data.stack}`
+
+    try {
+      return JSON.stringify(data, this.#jsonReplacer, 2)
+    } catch {
+      return String(data)
+    }
+  }
+
+  /**
+   * JSON replacer function to handle special objects like Error, Date, etc.
+   */
+  #jsonReplacer = (_key: string, value: any): any => {
+    if (value instanceof Error) return JSON.stringify(value, Object.getOwnPropertyNames(value))
+    if (value instanceof Date) return value.toISOString()
+    if (typeof value === 'bigint') return value.toString()
+    if (typeof value === 'function') return `[Function: ${value.name || 'anonymous'}]`
+    if (value === undefined) return '[undefined]'
+
+    return value
+  }
+
+  /**
+   * Helper to format log message with additional data
+   */
+  #formatMessage(message: string, data?: any): string {
+    if (!data) return message
+
+    const serializedData = this.#serialize(data)
+    return `${message}\n${serializedData}`
+  }
+
+  /**
+   * Generic log method that handles both Pino and BullMQ logging
+   */
+  #log(level: string, mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    const pinoLogMethod = this.#adonisLogger[level as keyof Logger] as (...args: any[]) => void
+
+    /**
+     * Called as level(message, ...values)
+     */
+    if (typeof mergingObjectOrMessage === 'string') {
+      pinoLogMethod.call(this.#adonisLogger, mergingObjectOrMessage, ...values)
+
+      if (!this.#logToBullMQ) return
+      const prefix = level.toUpperCase()
+      this.#bullJob.log(`${prefix}: ${mergingObjectOrMessage}`)
+
+      return
+    }
+
+    /**
+     * Called as level(mergingObject, message, ...values)
+     */
+    pinoLogMethod.call(this.#adonisLogger, mergingObjectOrMessage, message, ...values)
+
+    if (!this.#logToBullMQ) return
+    const prefix = level.toUpperCase()
+    this.#bullJob.log(`${prefix}: ${this.#formatMessage(message || '', mergingObjectOrMessage)}`)
+  }
+
+  info(mergingObject: any, message?: string, ...values: any[]): void
+  info(message: string, ...values: any[]): void
+  info(mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    this.#log('info', mergingObjectOrMessage, message, ...values)
+  }
+
+  error(mergingObject: any, message?: string, ...values: any[]): void
+  error(message: string, ...values: any[]): void
+  error(mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    this.#log('error', mergingObjectOrMessage, message, ...values)
+  }
+
+  warn(mergingObject: any, message?: string, ...values: any[]): void
+  warn(message: string, ...values: any[]): void
+  warn(mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    this.#log('warn', mergingObjectOrMessage, message, ...values)
+  }
+
+  debug(mergingObject: any, message?: string, ...values: any[]): void
+  debug(message: string, ...values: any[]): void
+  debug(mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    this.#log('debug', mergingObjectOrMessage, message, ...values)
+  }
+
+  trace(mergingObject: any, message?: string, ...values: any[]): void
+  trace(message: string, ...values: any[]): void
+  trace(mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    this.#log('trace', mergingObjectOrMessage, message, ...values)
+  }
+
+  fatal(mergingObject: any, message?: string, ...values: any[]): void
+  fatal(message: string, ...values: any[]): void
+  fatal(mergingObjectOrMessage: any, message?: string, ...values: any[]): void {
+    this.#log('fatal', mergingObjectOrMessage, message, ...values)
+  }
+
+  /**
+   * Create a child logger
+   */
+  child(bindings: Record<string, any>): JobLogger {
+    const childPinoLogger = this.#adonisLogger.child(bindings)
+    return new JobLogger({
+      adonisLogger: childPinoLogger,
+      bullJob: this.#bullJob,
+      options: { logToBullMQ: this.#logToBullMQ },
+    })
+  }
+}

--- a/packages/core/src/worker/worker.ts
+++ b/packages/core/src/worker/worker.ts
@@ -68,7 +68,7 @@ export class Worker<KnownQueues extends Record<string, QueueConfig> = Queues> {
    * Create a JobLogger instance with the current configuration
    */
   #createJobLogger(adonisLogger: Logger, job: BullJob): JobLogger {
-    const multiLoggerEnabled = this.#config.experimental?.multiLogger?.enabled ?? false
+    const multiLoggerEnabled = this.#config.multiLogger?.enabled ?? false
     return new JobLogger({
       adonisLogger,
       bullJob: job,

--- a/packages/core/src/worker/worker.ts
+++ b/packages/core/src/worker/worker.ts
@@ -1,7 +1,7 @@
 import { BullMQOtel } from 'bullmq-otel'
 import { trace } from '@opentelemetry/api'
+import { Logger } from '@adonisjs/core/logger'
 import { RuntimeException } from '@poppinss/utils'
-import type { Logger } from '@adonisjs/core/logger'
 import type { ApplicationService } from '@adonisjs/core/types'
 import type { EmitterLike } from '@adonisjs/core/types/events'
 
@@ -77,25 +77,55 @@ export class Worker<KnownQueues extends Record<string, QueueConfig> = Queues> {
   }
 
   /**
-   * Start processing a job
+   * Create a logger with trace context
    */
-  async #processJob(job: BullJob, token?: string) {
-    const JobClass = this.#getJobClass(job.name)
-
-    const currentSpan = trace.getActiveSpan()?.setAttribute('bullmq.job.name', job.name)
-    const spanContext = currentSpan?.spanContext()
-    const adonisLogger = this.#logger!.child({
+  #createTracedLogger(): Logger {
+    const spanContext = trace.getActiveSpan()?.spanContext()
+    return this.#logger!.child({
       trace_id: spanContext?.traceId,
       span_id: spanContext?.spanId,
       trace_flags: spanContext?.traceFlags?.toString(),
     })
+  }
 
+  #getJobClass(jobName: string) {
+    const JobClass = this.#jobs.get(jobName)
+    if (JobClass) return JobClass
+
+    const message = `Job "${String(jobName)}" was not found. If you changed the Job class name, make sure to use update the 'nameOverride' property.`
+    throw new RuntimeException(message)
+  }
+
+  /**
+   * Create a job instance with all dependencies configured
+   */
+  async #createJobInstance(options: { job: BullJob; token?: string; error?: Error }) {
+    const { job, token, error } = options
+
+    const JobClass = this.#getJobClass(job.name)
+    const adonisLogger = this.#createTracedLogger()
     const jobLogger = this.#createJobLogger(adonisLogger, job)
+    const resolver = this.#app.container.createResolver()
 
-    const jobInstance = await this.#app.container.make(JobClass)
-    jobInstance.$init(this.#bullWorker!, JobClass, job, token, jobLogger)
+    resolver.bindValue(Logger, jobLogger)
 
-    const result = this.#app.container.call(jobInstance, 'process')
+    const instance = await resolver.make(JobClass)
+    instance.$init(this.#bullWorker!, JobClass, job, token, jobLogger)
+
+    if (error) instance.$setError(error)
+
+    return { instance, resolver }
+  }
+
+  /**
+   * Start processing a job
+   */
+  async #processJob(job: BullJob, token?: string) {
+    trace.getActiveSpan()?.setAttribute('bullmq.job.name', job.name)
+
+    const { instance: jobInstance, resolver } = await this.#createJobInstance({ job, token })
+
+    const result = resolver.call(jobInstance, 'process')
     this.#emitter.emit('job:started', { job })
 
     return await result
@@ -105,30 +135,15 @@ export class Worker<KnownQueues extends Record<string, QueueConfig> = Queues> {
    * Called when a job fails
    */
   async #onJobFailed(job: BullJob | undefined, error: Error, token: string) {
-    const spanContext = trace.getActiveSpan()?.spanContext()
-    const logger = this.#logger!.child({
-      trace_id: spanContext?.traceId,
-      span_id: spanContext?.spanId,
-      trace_flags: spanContext?.traceFlags?.toString(),
-    })
-
+    const logger = this.#createTracedLogger()
     if (!job) return logger.error(error.message, 'Job failed')
 
     this.#emitter.emit('job:error', { job, error })
 
-    const JobClass = this.#getJobClass(job.name)
-    const jobInstance = await this.#app.container.make(JobClass)
+    const { instance: jobInstance, resolver } = await this.#createJobInstance({ job, token, error })
+    await resolver.call(jobInstance, 'onFailed')
 
-    const jobLogger = this.#createJobLogger(logger, job)
-
-    jobInstance.$init(this.#bullWorker!, JobClass, job, token, jobLogger)
-    jobInstance.$setError(error)
-
-    await this.#app.container.call(jobInstance, 'onFailed')
-
-    if (jobInstance.allAttemptsMade()) {
-      this.#emitter.emit('job:failed', { job, error })
-    }
+    if (jobInstance.allAttemptsMade()) this.#emitter.emit('job:failed', { job, error })
   }
 
   /**
@@ -136,14 +151,6 @@ export class Worker<KnownQueues extends Record<string, QueueConfig> = Queues> {
    */
   #onJobCompleted(job: BullJob) {
     this.#emitter.emit('job:success', { job })
-  }
-
-  #getJobClass(jobName: string) {
-    const JobClass = this.#jobs.get(jobName)
-    if (JobClass) return JobClass
-
-    const message = `Job "${String(jobName)}" was not found. If you changed the job class name, make sure to use update the 'nameOverride' property.`
-    throw new RuntimeException(message)
   }
 
   /**

--- a/playground/adonisrc.ts
+++ b/playground/adonisrc.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     },
     () => import('@nemoventures/adonis-jobs/queue_provider'),
     () => import('@julr/adonisjs-prometheus/prometheus_provider'),
+    () => import('#providers/app_provider'),
   ],
 
   /*

--- a/playground/app/jobs/write_file_job.ts
+++ b/playground/app/jobs/write_file_job.ts
@@ -1,5 +1,8 @@
+import { inject } from '@adonisjs/core'
 import { appendFile } from 'node:fs/promises'
 import { Job } from '@nemoventures/adonis-jobs'
+
+import { TestService } from '#services/test_service'
 
 export type TestJobData = {
   data: string
@@ -7,15 +10,20 @@ export type TestJobData = {
 
 export type TestJobReturn = {}
 
+@inject()
 export default class WriteFileJob extends Job<TestJobData, TestJobReturn> {
+  constructor(protected testService: TestService) {
+    super()
+  }
+
   async process(): Promise<TestJobReturn> {
     const delayMs = Math.random() * 5000 + 1000
+
+    this.testService.doSomething()
+
     this.logger.info(`Processing WriteFileJob with ${delayMs}ms delay`)
-
     this.logger.debug({ data: this.data }, 'WriteFileJob data')
-
     await new Promise((resolve) => setTimeout(resolve, delayMs))
-
     this.logger.error({ err: new Error('Test error') }, 'An error occurred in WriteFileJob')
 
     await appendFile('test.txt', this.data.data + '\n', 'utf8')

--- a/playground/app/jobs/write_file_job.ts
+++ b/playground/app/jobs/write_file_job.ts
@@ -12,7 +12,11 @@ export default class WriteFileJob extends Job<TestJobData, TestJobReturn> {
     const delayMs = Math.random() * 5000 + 1000
     this.logger.info(`Processing WriteFileJob with ${delayMs}ms delay`)
 
+    this.logger.debug({ data: this.data }, 'WriteFileJob data')
+
     await new Promise((resolve) => setTimeout(resolve, delayMs))
+
+    this.logger.error({ err: new Error('Test error') }, 'An error occurred in WriteFileJob')
 
     await appendFile('test.txt', this.data.data + '\n', 'utf8')
 

--- a/playground/app/services/test_service.ts
+++ b/playground/app/services/test_service.ts
@@ -1,0 +1,18 @@
+import { inject } from '@adonisjs/core'
+import { Logger } from '@adonisjs/core/logger'
+
+import { PaymentService } from '#providers/app_provider'
+
+@inject()
+export class TestService {
+  constructor(
+    protected logger: Logger,
+    private paymentService: PaymentService,
+  ) {}
+
+  async doSomething() {
+    this.logger.info('TestService is doing something!')
+
+    this.paymentService.processPayment(100)
+  }
+}

--- a/playground/config/queue.ts
+++ b/playground/config/queue.ts
@@ -3,12 +3,16 @@ import { defineConfig } from '@nemoventures/adonis-jobs'
 import env from '#start/env'
 
 const queueConfig = defineConfig({
+  experimental: { multiLogger: { enabled: true } },
+
   connection: {
     host: env.get('REDIS_HOST'),
     port: env.get('REDIS_PORT'),
     password: env.get('REDIS_PASSWORD'),
   },
+
   defaultQueue: 'default',
+
   queues: {
     default: {},
     test: {},

--- a/playground/config/queue.ts
+++ b/playground/config/queue.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@nemoventures/adonis-jobs'
 import env from '#start/env'
 
 const queueConfig = defineConfig({
-  experimental: { multiLogger: { enabled: true } },
+  multiLogger: { enabled: true },
 
   connection: {
     host: env.get('REDIS_HOST'),

--- a/playground/providers/app_provider.ts
+++ b/playground/providers/app_provider.ts
@@ -1,0 +1,47 @@
+import { inject } from '@adonisjs/core'
+import { Logger } from '@adonisjs/core/logger'
+import type { ApplicationService } from '@adonisjs/core/types'
+
+@inject()
+export abstract class PaymentService {
+  constructor(protected logger: Logger) {}
+
+  abstract processPayment(amount: number): Promise<void>
+}
+
+export class StripePaymentService extends PaymentService {
+  async processPayment(amount: number): Promise<void> {
+    this.logger.info(`Processing payment of $${amount} using Stripe`)
+  }
+}
+
+export default class AppProvider {
+  constructor(protected app: ApplicationService) {}
+
+  /**
+   * Register bindings to the container
+   */
+  register() {
+    this.app.container.singleton(PaymentService, (resolver) => resolver.make(StripePaymentService))
+  }
+
+  /**
+   * The container bindings have booted
+   */
+  async boot() {}
+
+  /**
+   * The application has been booted
+   */
+  async start() {}
+
+  /**
+   * The process has been started
+   */
+  async ready() {}
+
+  /**
+   * Preparing to shutdown the app
+   */
+  async shutdown() {}
+}

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@adonisjs/tsconfig/tsconfig.package.json",
+  "extends": "@adonisjs/tsconfig/tsconfig.app.json",
   "compilerOptions": {
     "rootDir": "./",
     "outDir": "./build",


### PR DESCRIPTION
gonna log through the Adonis logger, so with Pino, but also through Bull's logger. that way, we can see the logs in the Bull dashboard too

we’re building a big wrapper that extends the Adonis logger, so end-user can keep the same API, and we add the Bull logging functionnality on top of that

we need to stringify everything for Bull since it only accepts strings

as a side note: honestly, Queuedash does a poor job at displaying logs

![image](https://github.com/user-attachments/assets/3c1131c2-f0a2-4132-937f-0f7b47e27a3b)

should we keep it experimental for now? Or just drop the flag? i don't have a strong opinion, but either way I think it should be optional ?

