### PR TITLE
feat: shared connection + use @adonisjs/redis connections

### DIFF
--- a/packages/core/configure.ts
+++ b/packages/core/configure.ts
@@ -2,37 +2,9 @@ import type ConfigureCommand from '@adonisjs/core/commands/configure'
 
 import { stubsRoot } from './stubs/main.js'
 
-/**
- * List of supported transports
- */
-
 export async function configure(command: ConfigureCommand) {
   const codemods = await command.createCodemods()
-
-  // Publish config file
   await codemods.makeUsingStub(stubsRoot, 'config/queue.stub', {})
-
-  /**
-   * Add environment variables
-   */
-  await codemods.defineEnvVariables({
-    REDIS_HOST: '127.0.0.1',
-    REDIS_PORT: '6379',
-    REDIS_PASSWORD: '',
-    QUEUE_PORT: '3334',
-  })
-
-  /**
-   * Validate environment variables
-   */
-  await codemods.defineEnvValidations({
-    variables: {
-      REDIS_HOST: `Env.schema.string({ format: 'host' })`,
-      REDIS_PORT: 'Env.schema.number()',
-      REDIS_PASSWORD: 'Env.schema.string.optional()',
-      QUEUE_PORT: 'Env.schema.number()',
-    },
-  })
 
   /**
    * Publish provider and command
@@ -40,6 +12,5 @@ export async function configure(command: ConfigureCommand) {
   await codemods.updateRcFile((rcFile) => {
     rcFile.addProvider('@nemoventures/adonis-jobs/queue_provider')
     rcFile.addCommand('@nemoventures/adonis-jobs/commands')
-    rcFile.setDirectory('jobs', 'app/jobs')
   })
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
   "peerDependencies": {
     "@adonisjs/core": "^6.0.0",
     "@adonisjs/http-server": "^7.6.1",
+    "@adonisjs/redis": "^9.2.0",
     "@julr/adonisjs-prometheus": "^1.0.2",
     "@taskforcesh/bullmq-pro": "^7.35.2",
     "bullmq": "^5.53.2"
@@ -74,6 +75,7 @@
   "devDependencies": {
     "@adonisjs/assembler": "^7.8.2",
     "@adonisjs/core": "catalog:",
+    "@adonisjs/redis": "^9.2.0",
     "@japa/assert": "^4.0.1",
     "@japa/expect": "^3.0.4",
     "@japa/expect-type": "^2.0.3",

--- a/packages/core/providers/queue_provider.ts
+++ b/packages/core/providers/queue_provider.ts
@@ -4,6 +4,7 @@ import type { ApplicationService } from '@adonisjs/core/types'
 
 import { BullMqFactory } from '../src/bull_factory.js'
 import { QueueManager } from '../src/queue_manager.js'
+import { ConnectionResolver } from '../src/connection_resolver.js'
 import type { Config, JobEvents, Queues, QueueService } from '../src/types/index.js'
 
 /**
@@ -33,7 +34,9 @@ export default class JobProvider {
         )
       }
 
-      return new QueueManager(config)
+      const redis = await this.app.container.make('redis')
+      const connectionResolver = new ConnectionResolver(config, redis)
+      return new QueueManager(config, connectionResolver)
     })
   }
 

--- a/packages/core/src/connection_resolver.ts
+++ b/packages/core/src/connection_resolver.ts
@@ -1,0 +1,35 @@
+import type { RedisConnection } from '@adonisjs/redis'
+import type { RedisService } from '@adonisjs/redis/types'
+
+import type { BullConnectionOptions, Config, QueueConnectionConfig } from './types/index.js'
+
+export class ConnectionResolver {
+  #useSharedConnection = false
+
+  constructor(
+    private config: Config<any>,
+    private redis: RedisService,
+  ) {
+    this.#useSharedConnection = config.useSharedConnection ?? false
+  }
+
+  /**
+   * Resolve a connection configuration to BullMQ connection options
+   */
+  resolve(connectionConfig?: QueueConnectionConfig): BullConnectionOptions {
+    if (!connectionConfig) connectionConfig = this.config.connection
+
+    const redisConnection = this.redis.connection(
+      connectionConfig.connectionName,
+    ) as any as RedisConnection
+
+    if (this.#useSharedConnection) return redisConnection.ioConnection
+
+    /**
+     * For non-shared connections, we return the connection options
+     * in order to let BullMQ create a new IORedis instance.
+     */
+    const ioConnection = redisConnection.ioConnection
+    return { ...ioConnection.options, maxRetriesPerRequest: null }
+  }
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,8 +1,9 @@
 import type { ConfigProvider } from '@adonisjs/core/types'
+import type { RedisConnections } from '@adonisjs/redis/types'
 
 import type { BaseJob } from '../job/base_job.js'
 import type { QueueManager } from '../queue_manager.js'
-import type { BullQueueOptions, BullWorkerOptions, BullConnectionOptions } from './bull.js'
+import type { BullQueueOptions, BullWorkerOptions } from './bull.js'
 
 export * from './scheduler.js'
 export * from './events.js'
@@ -11,10 +12,19 @@ export type { JobConstructor } from '../job/job.js'
 
 export interface QueueService extends QueueManager {}
 
-export type Config<KnownQueues extends Record<string, QueueConfig>> = {
-  connection: BullConnectionOptions
+/**
+ * Connection configuration types
+ */
+export interface QueueConnectionConfig {
+  connectionName: keyof RedisConnections
+}
+
+export interface Config<KnownQueues extends Record<string, QueueConfig>> {
+  connection: QueueConnectionConfig
+  useSharedConnection?: boolean
   defaultQueue: keyof KnownQueues
   queues: KnownQueues
+
   /**
    * Multi logger allows you to use the AdonisJS logger as usual within your jobs,
    * but logs will be sent to both your configured Pino destinations (console, files, etc.)
@@ -24,6 +34,7 @@ export type Config<KnownQueues extends Record<string, QueueConfig>> = {
 }
 
 export type QueueConfig = Omit<BullQueueOptions, 'connection' | 'skipVersionCheck'> & {
+  connection?: QueueConnectionConfig
   globalConcurrency?: number
   defaultWorkerOptions?: WorkerOptions
 }

--- a/packages/core/src/worker/worker_manager.ts
+++ b/packages/core/src/worker/worker_manager.ts
@@ -3,12 +3,14 @@ import type { EmitterLike } from '@adonisjs/core/types/events'
 
 import { Worker } from './worker.js'
 import type { BaseJobConstructor } from '../job/base_job.js'
+import type { ConnectionResolver } from '../connection_resolver.js'
 import type { Config, JobEvents, QueueConfig, Queues } from '../types/index.js'
 
 export class WorkerManager<KnownQueues extends Record<string, QueueConfig> = Queues> {
   readonly #app: ApplicationService
   readonly #emitter: EmitterLike<JobEvents>
   readonly #jobs: Map<string, BaseJobConstructor>
+  readonly #connectionResolver: ConnectionResolver
   #runningWorkers: Worker<KnownQueues>[] = []
 
   constructor(
@@ -16,10 +18,12 @@ export class WorkerManager<KnownQueues extends Record<string, QueueConfig> = Que
     emitter: EmitterLike<JobEvents>,
     public config: Config<KnownQueues>,
     jobs: BaseJobConstructor[],
+    connectionResolver: ConnectionResolver,
   ) {
     this.#app = app
     this.#emitter = emitter
     this.#jobs = new Map(jobs.map((j) => [j.jobName, j]))
+    this.#connectionResolver = connectionResolver
   }
 
   getAllQueueNames() {
@@ -33,6 +37,7 @@ export class WorkerManager<KnownQueues extends Record<string, QueueConfig> = Que
       jobs: this.#jobs,
       config: this.config,
       emitter: this.#emitter,
+      connectionResolver: this.#connectionResolver,
     })
 
     worker.start()

--- a/packages/core/stubs/config/queue.stub
+++ b/packages/core/stubs/config/queue.stub
@@ -2,17 +2,47 @@
   exports({ to: app.configPath('queue.ts') })
 }}}
 import { defineConfig } from '@nemoventures/adonis-jobs'
-import env from "#start/env";
 
 const queueConfig = defineConfig({
-  connection: {
-    host: env.get('REDIS_HOST'),
-    port: env.get('REDIS_PORT'),
-    password: env.get('REDIS_PASSWORD'),
-  },
+  /**
+   * The default connection to use. The connection
+   * should be defined in the "config/redis.ts" file.
+   */
+  connection: { connectionName: 'main' },
+
+  /**
+   * When enabled, all queues will use the same Redis connection instance.
+   * This is the recommended setting for most applications.
+   */
+  useSharedConnection: true,
+
+  /**
+   * The name of the queue to use when no queue is explicitly specified
+   * during job dispatching.
+   */
   defaultQueue: 'default',
+
+  /**
+   * Configure your queues here. Each queue can have its own connection,
+   * worker options, and job options
+   */
   queues: {
+    /**
+     * The default queue for processing jobs
+     */
     default: {},
+
+    /**
+     * Example of a queue with specific connection and options
+     */
+    // priority: {
+    //   connection: { connectionName: 'priority' },
+    //   globalConcurrency: 5,
+    //   defaultWorkerOptions: {
+    //     removeOnComplete: 10,
+    //     removeOnFail: 50,
+    //   },
+    // },
   },
 })
 

--- a/packages/core/tests/unit/define_config.spec.ts
+++ b/packages/core/tests/unit/define_config.spec.ts
@@ -10,7 +10,7 @@ const app = new AppFactory().create(BASE_URL, () => {}) as ApplicationService
 await app.init()
 
 const queueConfigProvider = defineConfig({
-  connection: {},
+  connection: { connectionName: 'default' as never },
   defaultQueue: 'default',
   queues: {
     default: {},

--- a/playground/adonisrc.ts
+++ b/playground/adonisrc.ts
@@ -49,6 +49,7 @@ export default defineConfig({
     () => import('@nemoventures/adonis-jobs/queue_provider'),
     () => import('@julr/adonisjs-prometheus/prometheus_provider'),
     () => import('#providers/app_provider'),
+    () => import('@adonisjs/redis/redis_provider')
   ],
 
   /*

--- a/playground/compose.yml
+++ b/playground/compose.yml
@@ -4,17 +4,18 @@ services:
     container_name: adonis-jobs-redis
     ports:
       - '6379:6379'
-    volumes:
-      - redis_data:/data
     environment:
       - REDIS_ARGS=--save 60 1000 --loglevel warning
-    restart: unless-stopped
-    healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+    networks:
+      - monitoring
+
+  redis-secondary:
+    image: redis:8-alpine
+    container_name: adonis-jobs-redis-secondary
+    ports:
+      - '6380:6379'
+    environment:
+      - REDIS_ARGS=--save 60 1000 --loglevel warning
     networks:
       - monitoring
 
@@ -76,8 +77,6 @@ networks:
     driver: bridge
 
 volumes:
-  redis_data:
-    driver: local
   prometheus_data:
     driver: local
   grafana_data:

--- a/playground/config/queue.ts
+++ b/playground/config/queue.ts
@@ -1,21 +1,32 @@
 import { defineConfig } from '@nemoventures/adonis-jobs'
 
-import env from '#start/env'
-
 const queueConfig = defineConfig({
-  multiLogger: { enabled: true },
+  /**
+   * The default connection to use. The connection
+   * should be defined in the "config/redis.ts" file.
+   */
+  connection: { connectionName: 'queues' },
 
-  connection: {
-    host: env.get('REDIS_HOST'),
-    port: env.get('REDIS_PORT'),
-    password: env.get('REDIS_PASSWORD'),
-  },
+  /**
+   * When enabled, all queues will use the same Redis connection instance.
+   * This is the recommended setting for most applications.
+   */
+  useSharedConnection: true,
 
+  /**
+   * The name of the queue to use when no queue is explicitly specified
+   * during job dispatching.
+   */
   defaultQueue: 'default',
 
+  /**
+   * Configure your queues here. Each queue can have its own connection,
+   * worker options, and job options
+   */
   queues: {
     default: {},
-    test: {},
+    notifications: {},
+    mails: {},
   },
 })
 
@@ -23,8 +34,4 @@ export default queueConfig
 
 declare module '@nemoventures/adonis-jobs/types' {
   interface Queues extends InferQueues<typeof queueConfig> {}
-
-  interface BullVersion {
-    version: 'pro'
-  }
 }

--- a/playground/config/redis.ts
+++ b/playground/config/redis.ts
@@ -26,6 +26,16 @@ const redisConfig = defineConfig({
       retryStrategy(times) {
         return times > 10 ? null : times * 50
       },
+      maxRetriesPerRequest: null,
+    },
+
+    queues: {
+      host: env.get('REDIS_HOST'),
+      port: 6380,
+      password: env.get('REDIS_PASSWORD', ''),
+      db: 0,
+      keyPrefix: '',
+      maxRetriesPerRequest: null,
     },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@adonisjs/core':
         specifier: 'catalog:'
         version: 6.18.0(@adonisjs/assembler@7.8.2(typescript@5.8.3))
+      '@adonisjs/redis':
+        specifier: ^9.2.0
+        version: 9.2.0(@adonisjs/core@6.18.0(@adonisjs/assembler@7.8.2(typescript@5.8.3)))
       '@japa/assert':
         specifier: ^4.0.1
         version: 4.0.1(@japa/runner@4.2.0)


### PR DESCRIPTION
- shared connection management, this is optional. we can now use `config.useSharedConnection: false` to keep unique connections for each BullMQ element. we can also define a specific connection for each queue => Imagine a hyper-critical queue or one with a huge throughput, you can define a specific connection just for it and use shared connections for the others

- Also, we now use @adonisjs/redis connections rather than defining them inline in config/queue.ts