### PR TITLE
feat!: scheduled command jobs + changed API for dispatching command jobs

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -9,6 +9,7 @@ import type { BullQueueOptions, BullWorkerOptions } from './bull.js'
 export * from './scheduler.js'
 export * from './events.js'
 export * from './bull.js'
+export * from './job.js'
 export type { JobConstructor } from '../job/job.js'
 
 /**

--- a/packages/core/src/types/job.ts
+++ b/packages/core/src/types/job.ts
@@ -1,0 +1,7 @@
+import type { BaseJobConstructor } from '../job/base_job.js'
+
+export interface PrebuiltJobData<TJobData = Record<string, any>, TAdditionalData = {}> {
+  job: BaseJobConstructor
+  data: TJobData
+  additionalData?: TAdditionalData
+}

--- a/packages/core/src/types/scheduler.ts
+++ b/packages/core/src/types/scheduler.ts
@@ -1,15 +1,25 @@
+import type { PrebuiltJobData } from './job.js'
 import type { BaseJobConstructor } from '../job/base_job.js'
-import type { BullJobsOptions, Queues, BullRepeatOptions } from './index.js'
+import type { BullJobsOptions, Queues, BullRepeatOptions, InferDataType } from './index.js'
 
 export interface SchedulerRepeatOptions extends Omit<BullRepeatOptions, 'key' | 'jobId'> {}
 
-export interface ScheduleJobOptions<T> {
+interface BaseScheduleOptions {
   key: string
   repeat: SchedulerRepeatOptions
-  job: BaseJobConstructor
-  data: T
   options?: BullJobsOptions
   queue?: keyof Queues
+}
+
+export interface ScheduleJobOptions<J extends BaseJobConstructor> extends BaseScheduleOptions {
+  job: J
+  data: InferDataType<InstanceType<J>>
+}
+
+export interface ScheduleJobOptionsWithPrebuilt<TPrebuiltJob extends PrebuiltJobData<any>>
+  extends BaseScheduleOptions {
+  job: TPrebuiltJob
+  data?: TPrebuiltJob['additionalData']
 }
 
 export interface ScheduledJobInfo {

--- a/packages/core/tests/fixtures/cleanup.ts
+++ b/packages/core/tests/fixtures/cleanup.ts
@@ -1,0 +1,16 @@
+import { BaseCommand, flags } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+
+export default class Cleanup extends BaseCommand {
+  static commandName = 'cleanup'
+  static description = ''
+
+  @flags.boolean({ description: 'Force cleanup' })
+  declare force: boolean
+
+  static options: CommandOptions = {}
+
+  async run() {
+    this.logger.info(`Force cleanup is ${this.force ? 'enabled' : 'disabled'}`)
+  }
+}

--- a/packages/core/tests/fixtures/fake_job.ts
+++ b/packages/core/tests/fixtures/fake_job.ts
@@ -1,0 +1,7 @@
+import { Job } from '#job/job'
+
+export class FakeJob extends Job<{ foo: string; bar: number }, void> {
+  async process() {
+    this.logger.info('Fake job executed with data:', this.data)
+  }
+}

--- a/packages/core/tests/unit/job_scheduler.spec.ts
+++ b/packages/core/tests/unit/job_scheduler.spec.ts
@@ -1,0 +1,38 @@
+import { test } from '@japa/runner'
+
+import Cleanup from '../fixtures/cleanup.js'
+import type { JobScheduler } from '#job/job_scheduler'
+
+test.group('Job Scheduler', () => {
+  test('Schedule Typings', async ({ expectTypeOf }) => {
+    const { FakeJob } = await import('../fixtures/fake_job.js')
+    const { default: CommandJob } = await import('../../src/builtin/command_job.js')
+
+    const p1 = {
+      key: 'test-command-job',
+      job: CommandJob.from(Cleanup),
+      repeat: { pattern: '*/10 * * * * *' },
+      data: { args: ['--verbose'] },
+    }
+
+    expectTypeOf<typeof JobScheduler.schedule>().toBeCallableWith(p1)
+
+    const p2 = {
+      key: 'test-command-job',
+      job: CommandJob.from(Cleanup),
+      repeat: { pattern: '*/10 * * * * *' },
+      data: {},
+    }
+
+    expectTypeOf<typeof JobScheduler.schedule>().toBeCallableWith(p2)
+
+    const p3 = {
+      key: 'fake-job',
+      job: FakeJob,
+      data: { bar: 342, foo: 'foo' },
+      repeat: { pattern: '*/5 * * * * *' },
+    }
+
+    expectTypeOf<typeof JobScheduler.schedule>().toBeCallableWith(p3)
+  }).skip(true, 'Type checking only')
+})

--- a/playground/app/jobs/write_file_job.ts
+++ b/playground/app/jobs/write_file_job.ts
@@ -24,7 +24,7 @@ export default class WriteFileJob extends Job<TestJobData, TestJobReturn> {
     this.logger.info(`Processing WriteFileJob with ${delayMs}ms delay`)
     this.logger.debug({ data: this.data }, 'WriteFileJob data')
     await new Promise((resolve) => setTimeout(resolve, delayMs))
-    this.logger.error({ err: new Error('Test error') }, 'An error occurred in WriteFileJob')
+    // this.logger.error({ err: new Error('Test error') }, 'An error occurred in WriteFileJob')
 
     await appendFile('test.txt', this.data.data + '\n', 'utf8')
 

--- a/playground/app/services/payment_service.ts
+++ b/playground/app/services/payment_service.ts
@@ -1,0 +1,15 @@
+import { inject } from '@adonisjs/core'
+import { Logger } from '@adonisjs/core/logger'
+
+@inject()
+export abstract class PaymentService {
+  constructor(protected logger: Logger) {}
+
+  abstract processPayment(amount: number): Promise<void>
+}
+
+export class StripePaymentService extends PaymentService {
+  async processPayment(amount: number): Promise<void> {
+    this.logger.info(`Processing payment of $${amount} using Stripe`)
+  }
+}

--- a/playground/app/services/test_service.ts
+++ b/playground/app/services/test_service.ts
@@ -1,7 +1,7 @@
 import { inject } from '@adonisjs/core'
 import { Logger } from '@adonisjs/core/logger'
 
-import { PaymentService } from '#providers/app_provider'
+import { PaymentService } from '#services/payment_service'
 
 @inject()
 export class TestService {

--- a/playground/commands/cleanup.ts
+++ b/playground/commands/cleanup.ts
@@ -1,0 +1,16 @@
+import { BaseCommand, flags } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+
+export default class Cleanup extends BaseCommand {
+  static commandName = 'cleanup'
+  static description = ''
+
+  @flags.boolean({ description: 'Force cleanup' })
+  declare force: boolean
+
+  static options: CommandOptions = {}
+
+  async run() {
+    this.logger.info(`Force cleanup is ${this.force ? 'enabled' : 'disabled'}`)
+  }
+}

--- a/playground/providers/app_provider.ts
+++ b/playground/providers/app_provider.ts
@@ -1,27 +1,11 @@
-import { inject } from '@adonisjs/core'
-import { Logger } from '@adonisjs/core/logger'
 import type { ApplicationService } from '@adonisjs/core/types'
 
-@inject()
-export abstract class PaymentService {
-  constructor(protected logger: Logger) {}
-
-  abstract processPayment(amount: number): Promise<void>
-}
-
-export class StripePaymentService extends PaymentService {
-  async processPayment(amount: number): Promise<void> {
-    this.logger.info(`Processing payment of $${amount} using Stripe`)
-  }
-}
+import { PaymentService, StripePaymentService } from '../app/services/payment_service.js'
 
 export default class AppProvider {
   constructor(protected app: ApplicationService) {}
 
-  /**
-   * Register bindings to the container
-   */
-  register() {
+  async register() {
     this.app.container.singleton(PaymentService, (resolver) => resolver.make(StripePaymentService))
   }
 

--- a/playground/start/routes.ts
+++ b/playground/start/routes.ts
@@ -9,9 +9,11 @@
 
 import router from '@adonisjs/core/services/router'
 import { JobScheduler } from '@nemoventures/adonis-jobs'
+import CommandJob from '@nemoventures/adonis-jobs/builtin/command_job'
 import { queueDashUiRoutes } from '@nemoventures/adonis-jobs/ui/queuedash'
 
 import SlowJob from '#jobs/slow_job'
+import Cleanup from '../commands/cleanup.js'
 import WriteFileJob from '../app/jobs/write_file_job.js'
 import NotificationJob from '../app/modules/notifications/jobs/notification_job.js'
 
@@ -50,6 +52,24 @@ router.get('/test-scheduler/:queue?', async ({ params }) => {
   })
 
   return 'Job scheduled via JobScheduler!'
+})
+
+/**
+ * Command Jobs
+ */
+router.get('/scheduled-command-job', async () => {
+  await JobScheduler.schedule({
+    key: 'test-command-job',
+    job: CommandJob.from(Cleanup),
+    data: { args: ['--force'] },
+    repeat: { pattern: '*/10 * * * * *' },
+  })
+
+  return 'Command job scheduled!'
+})
+
+router.get('/command-job', async () => {
+  await CommandJob.from(Cleanup).dispatch({ args: ['--force'] })
 })
 
 router.get('/list-scheduled', async () => {


### PR DESCRIPTION
Breaking ⚠️ : For dispatching command jobs, now we should use 

```ts
await CommandJob.from(Cleanup).dispatch({ args: ['--force'] })
```

And now CommandJob are supported through JobScheduler :

```ts
await JobScheduler.schedule({
  key: 'test-command-job',
  job: CommandJob.from(Cleanup),
  data: { args: ['--force'] },
  repeat: { pattern: '*/10 * * * * *' },
})
  ```