### PR TITLE
feat: add job default options

### DIFF
--- a/docs/src/content/docs/guides/creating-jobs.md
+++ b/docs/src/content/docs/guides/creating-jobs.md
@@ -119,6 +119,45 @@ export default class SendEmailJob extends Job<SendEmailJobData, void> {
 
 Now all instances of this job will use the `emails` queue unless overridden during dispatch.
 
+## Default Options
+
+Set default BullMQ options for a job class to avoid repeating them every time you dispatch:
+
+```typescript
+import { Job } from '@nemoventures/adonis-jobs'
+import type { BullJobsOptions } from '@nemoventures/adonis-jobs/types'
+
+export default class SyncAirdropsJob extends Job<SyncAirdropsData, void> {
+  static options: BullJobsOptions = {
+    attempts: 5,
+    backoff: {
+      type: 'exponential',
+      delay: 1000,
+    },
+    removeOnComplete: 10,
+    removeOnFail: 50,
+  }
+
+  async process(): Promise<void> {
+    // Job logic
+  }
+}
+```
+
+Now you can dispatch the job without having to specify options every time:
+
+```typescript
+// These options will be automatically applied
+await SyncAirdropsJob.dispatch(data)
+
+// You can still override specific options if needed when dispatching
+await SyncAirdropsJob.dispatch(data)
+  .with('attempts', 3)
+  .with('delay', 5000)
+```
+
+The `.with()` method will merge with and override the default options.
+
 ## Error Handling
 
 ### Failing Jobs

--- a/docs/src/content/docs/guides/creating-jobs.md
+++ b/docs/src/content/docs/guides/creating-jobs.md
@@ -127,7 +127,7 @@ Set default BullMQ options for a job class to avoid repeating them every time yo
 import { Job } from '@nemoventures/adonis-jobs'
 import type { BullJobsOptions } from '@nemoventures/adonis-jobs/types'
 
-export default class SyncAirdropsJob extends Job<SyncAirdropsData, void> {
+export default class SendEmailJob extends Job<void, void> {
   static options: BullJobsOptions = {
     attempts: 5,
     backoff: {
@@ -148,10 +148,10 @@ Now you can dispatch the job without having to specify options every time:
 
 ```typescript
 // These options will be automatically applied
-await SyncAirdropsJob.dispatch(data)
+await SendEmailJob.dispatch(data)
 
 // You can still override specific options if needed when dispatching
-await SyncAirdropsJob.dispatch(data)
+await SendEmailJob.dispatch(data)
   .with('attempts', 3)
   .with('delay', 5000)
 ```

--- a/packages/core/src/job/base_job.ts
+++ b/packages/core/src/job/base_job.ts
@@ -4,7 +4,14 @@ import type { Logger } from '@adonisjs/core/logger'
 import encryption from '@adonisjs/core/services/encryption'
 
 import { BullMqFactory } from '../bull_factory.js'
-import type { BullJob, BullWorker, InferDataType, InferReturnType, Queues } from '../types/index.js'
+import type {
+  BullJob,
+  BullWorker,
+  InferDataType,
+  InferReturnType,
+  Queues,
+  BullJobsOptions,
+} from '../types/index.js'
 
 export type BaseJobConstructor<JobInstance extends BaseJob<any, any> = BaseJob<any, any>> = {
   new (...args: any[]): JobInstance
@@ -12,6 +19,7 @@ export type BaseJobConstructor<JobInstance extends BaseJob<any, any> = BaseJob<a
   nameOverride?: string
   defaultQueue?: keyof Queues
   encrypted?: boolean
+  options?: BullJobsOptions
   jobName: string
 
   isInstanceOf<J extends JobInstance>(
@@ -38,6 +46,12 @@ export abstract class BaseJob<DataType, ReturnType> {
    * Encrypt job data sent to workers
    */
   static encrypted?: boolean
+
+  /**
+   * Default options for this job. These options will be applied to all instances
+   * of this job unless overridden during dispatch.
+   */
+  static options?: BullJobsOptions
 
   data!: DataType
   job!: BullJob<DataType, ReturnType>

--- a/packages/core/src/job/job_dispatcher.ts
+++ b/packages/core/src/job/job_dispatcher.ts
@@ -33,6 +33,7 @@ export class JobDispatcher<
     this.#jobClass = jobClass
     this.#data = data
     this.#queueName = jobClass.defaultQueue
+    this.#options = { ...jobClass.options }
   }
 
   /**

--- a/packages/core/stubs/make/job/main.stub
+++ b/packages/core/stubs/make/job/main.stub
@@ -4,12 +4,15 @@
   })
 }}}
 import { Job } from '@nemoventures/adonis-jobs'
+import type { BullJobsOptions } from '@nemoventures/adonis-jobs/types'
 
 export type {{ jobName }}Data = { }
 
 export type {{ jobName }}Return = { }
 
 export default class {{ jobName }} extends Job<{{ jobName }}Data, {{ jobName }}Return> {
+  static options: BullJobsOptions = {}
+
   async process(): Promise<{{ jobName }}Return> {
     throw new Error('Job processor not implemented.')
   }


### PR DESCRIPTION
Can now define default options in a job : 

```ts
import { Job } from '@nemoventures/adonis-jobs'
import type { BullJobsOptions } from '@nemoventures/adonis-jobs/types'

export default class MyJob extends MyJob {
  static options: BullJobsOptions = {
    attempts: 5,
    backoff: {
      type: 'exponential',
      delay: 1000,
    }
  }
}
```
Still can override them when dispatching with `with()`