### PR TITLE
feat: add otel configuration

### DIFF
--- a/docs/docs/pages/guides/observability.mdx
+++ b/docs/docs/pages/guides/observability.mdx
@@ -88,6 +88,22 @@ Under the hood, it uses the `bullmq-otel` package created by the BullMQ team, wh
 
 For every job processed, we are internally adding a `bullmq.job.name` attribute to the span, which contains the job class name.
 
+You can also define additional attributes for each span created during the job process.
+For example, if you want to add a default attribute `apm.root_name` containing the job name, you can configure the `otel` option in your `config/queue.ts` file:
+
+```typescript
+const queueConfig = defineConfig({
+  // ...
+  otel: {
+    defaultJobAttributes: (jobInstance) => ({
+      ['apm.root_name']: jobInstance.job.name,
+    }),
+  },
+})
+
+```
+
+
 Make sure to check out the [BullMQ OpenTelemetry documentation](https://docs.bullmq.io/guide/telemetry/getting-started) if you are new to using OpenTelemetry as it provides a quick start guide for setting up tracing in your application.
 
 ## Job Logging

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { Attributes } from '@opentelemetry/api'
 import type { ConfigProvider } from '@adonisjs/core/types'
 import type { RedisClusterConnection } from '@adonisjs/redis'
 import type { RedisConnections } from '@adonisjs/redis/types'
@@ -37,6 +38,17 @@ export interface MetricsConfig {
   endpoint?: string
 }
 
+/**
+ * OpenTelemetry configuration
+ */
+export interface OtelConfig {
+  /**
+   * Additional default attributes for the span created within each job.
+   * Internally, we already add an attribute `bullmq.job.name` with the job name.
+   */
+  defaultJobAttributes?: (job: BaseJob<any, any>) => Attributes
+}
+
 export interface QueueService extends QueueManager {}
 
 /**
@@ -55,6 +67,7 @@ export interface Config<
   queues: KnownQueues
   healthCheck?: HealthCheckConfig
   metrics?: MetricsConfig
+  otel?: OtelConfig
 
   /**
    * Multi logger allows you to use the AdonisJS logger as usual within your jobs,

--- a/packages/core/stubs/config/queue.stub
+++ b/packages/core/stubs/config/queue.stub
@@ -41,6 +41,19 @@ const queueConfig = defineConfig({
   // },
 
   /**
+   * OpenTelemetry configuration
+   */
+  // otel: {
+  //   /**
+  //    * Additional default attributes for the span created within each job.
+  //    * Internally, we already add an attribute `bullmq.job.name` with the job name.
+  //    */
+  //   defaultJobAttributes: (jobInstance) => ({
+  //     ['apm.root_name']: jobInstance.job.name,
+  //   }),
+  // },
+
+  /**
    * The name of the queue to use when no queue is explicitly specified
    * during job dispatching.
    */


### PR DESCRIPTION
### Linked issue 

https://github.com/nemoengineering/adonis-jobs/issues/83

### Description

Introduce an `otel` option to configure additional default attributes for the span created within each job.
It also keeps the actual attribute `bullmq.job.name`.