### PR TITLE
feat: Add "queue" alias to match documentation

### DIFF
--- a/packages/core/commands/queue/queue_work.ts
+++ b/packages/core/commands/queue/queue_work.ts
@@ -19,7 +19,7 @@ export default class QueueWork extends BaseCommand {
   static commandName = 'queue:work'
   static description = 'Listen for dispatched jobs'
 
-  @flags.array({ name: 'queues', alias: 'q', description: 'The queues you want to listen for' })
+  @flags.array({ name: 'queues', alias: ['queue', 'q'], description: 'The queues you want to listen for' })
   declare queues: (keyof Queues)[]
 
   @flags.boolean({ name: 'list', alias: 'l', description: 'List all available queues' })


### PR DESCRIPTION
This PR fixes [a mismatch between the documentation and the actual command flags](https://github.com/nemoengineering/adonis-jobs/issues/92).

---

The documentation currently shows usage examples such as:
`queue:work --queue=default --queue=email`

However, the command implementation only defines the following flags:
- `--queues`
- `-q` (alias)

As a result, using `--queue` produces:
`ERROR Unknown flag "--queue"`

This commit adds the "queue" alias so the command accepts:
- `--queue`
- `--queues`
- `-q`

This change ensures consistency with the documentation and improves usability for users following the provided examples. No breaking changes introduced.
