### PR TITLE
fix(core): add port config option and fix enabled flag for health check

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -19,6 +19,11 @@ export type { JobConstructor } from '../job/job.js'
 export interface HealthCheckConfig {
   enabled: boolean
   endpoint?: string
+  /**
+   * Port for the health check server. Defaults to 3333.
+   * Can also be set via QUEUE_PORT or PORT environment variables.
+   */
+  port?: number
   checks?: (context: { connection: RedisClusterConnection }) => any[]
 }
 


### PR DESCRIPTION
- Add optional `port` property to HealthCheckConfig type
- Fix `enabled: false` not preventing HTTP server startup
- Server now only starts if healthCheck or metrics are enabled
- Port priority: QUEUE_PORT env > PORT env > config.healthCheck.port > 3333

Fixes #77 