### PR TITLE
fix: escape backticks in queue.stub to fix tempura template parsing

### DIFF
--- a/packages/core/stubs/config/queue.stub
+++ b/packages/core/stubs/config/queue.stub
@@ -46,7 +46,7 @@ const queueConfig = defineConfig({
   // otel: {
   //   /**
   //    * Additional default attributes for the span created within each job.
-  //    * Internally, we already add an attribute `bullmq.job.name` with the job name.
+  //    * Internally, we already add an attribute 'bullmq.job.name' with the job name.
   //    */
   //   defaultJobAttributes: (jobInstance) => ({
   //     ['apm.root_name']: jobInstance.job.name,


### PR DESCRIPTION
## Summary
The `queue.stub` template file fails to parse when running `node ace configure @nemoventures/adonis-jobs` due to backticks in a comment being interpreted as template expressions by the tempura engine.

## Problem
Line 49 of `build/config/queue.stub` contains:
```
// * Internally, we already add an attribute `bullmq.job.name` with the job name.
```
The tempura template engine interprets backticks as template expressions, causing it to try to evaluate `bullmq.job.name` as JavaScript code, resulting in:
```
SyntaxError: Unexpected identifier 'bullmq'
at anonymous (/path/to/node_modules/@nemoventures/adonis-jobs/build/config/queue.stub:0:0)
at new Function ()
at Module.compile (tempura/dist/index.mjs:130:9)
```
## Fix
Replace backticks with single quotes in the comment:
```diff
- //    * Internally, we already add an attribute `bullmq.job.name` with the job name.
+ //    * Internally, we already add an attribute 'bullmq.job.name' with the job name.
```
## Testing

After this fix, node ace configure @nemoventures/adonis-jobs completes successfully.