### PR TITLE
chore: enforce 7-day minimum release age for dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ CI's `.github/actions/setup` runs `pnpm --filter @nemoventures/adonis-jobs build
 - Node **>=24** required by `packages/core` (`engines.node`). CI matrix tests on 22.x and 24.x; lint/typecheck/release pin to 24.
 - pnpm 10.32.1 via Corepack (`packageManager` field). Do not switch to npm/yarn.
 - `.npmrc` configures the private `@taskforcesh` registry for `@taskforcesh/bullmq-pro`. `pnpm install` requires `BULLMQ_PRO_TOKEN` in the environment (CI secret). Without it install will fail. `bullmq-pro` is an optional peer dep — code paths must not assume it.
+- `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days). Lockfile installs are unaffected, but `pnpm add` / `pnpm update` will refuse versions published in the last 7 days. Override per-invocation with `--ignore-minimum-release-age`.
 
 ## Conventions worth knowing
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,9 @@ packages:
 
 catalog:
   '@adonisjs/core': ^7.1.1
+
+# Reject dependency versions younger than 7 days at resolution time.
+# Mitigates supply-chain risk (malicious or compromised releases are
+# usually reported and yanked within this window).
+# Escape hatch for urgent adoption: `pnpm add ... --ignore-minimum-release-age`.
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Adds pnpm's `minimumReleaseAge: 10080` setting (7 days, in minutes) to `pnpm-workspace.yaml`. pnpm will refuse to resolve dependency versions published less than 7 days ago.

## Why

Supply-chain hardening. Malicious npm releases (typosquats, compromised maintainer accounts, intentionally backdoored versions) are typically detected and yanked within a few days of publish. Forcing a 7-day cooling-off period before we adopt any new version dramatically reduces the chance of pulling in a compromised release.

## Behavior

- **Lockfile installs are unaffected.** The constraint only fires during version *resolution* (i.e., `pnpm add`, `pnpm update`, or installing without a lockfile entry). CI runs against `main` continue to work unchanged.
- **`pnpm add` / `pnpm update` will error** when the target version is younger than 7 days. Per-invocation escape hatch: `--ignore-minimum-release-age`.
- Catalog references and workspace deps (`workspace:*`) are unaffected — they don't go through registry resolution.

## Changes

- `pnpm-workspace.yaml`: add `minimumReleaseAge: 10080` with a short inline comment explaining the rationale and escape hatch.
- `AGENTS.md`: one bullet under "Node, package manager, registry" so future agents (and humans) know the setting and its override exist.

## Verification

- `pnpm install` — completes from the existing lockfile in under a second ("Already up to date"). Confirms the setting does not retroactively reject locked versions.