### PR TITLE
chore: exempt @taskforcesh/bullmq-pro from minimumReleaseAge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ CI's `.github/actions/setup` runs `pnpm --filter @nemoventures/adonis-jobs build
 - Node **>=24** required by `packages/core` (`engines.node`). CI matrix tests on 22.x and 24.x; lint/typecheck/release pin to 24.
 - pnpm 10.32.1 via Corepack (`packageManager` field). Do not switch to npm/yarn.
 - `.npmrc` configures the private `@taskforcesh` registry for `@taskforcesh/bullmq-pro`. `pnpm install` requires `BULLMQ_PRO_TOKEN` in the environment (CI secret). Without it install will fail. `bullmq-pro` is an optional peer dep — code paths must not assume it.
-- `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days). Lockfile installs are unaffected, but `pnpm add` / `pnpm update` will refuse versions published in the last 7 days. Override per-invocation with `--ignore-minimum-release-age`.
+- `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days). Lockfile installs are unaffected, but `pnpm add` / `pnpm update` will refuse versions published in the last 7 days. Override per-invocation with `--ignore-minimum-release-age`. `@taskforcesh/bullmq-pro` is exempted via `minimumReleaseAgeExclude` (private commercial registry).
 
 ## Conventions worth knowing
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,6 @@ packages:
 catalog:
   '@adonisjs/core': ^7.1.1
 
-# Reject dependency versions younger than 7 days at resolution time.
-# Mitigates supply-chain risk (malicious or compromised releases are
-# usually reported and yanked within this window).
-# Escape hatch for urgent adoption: `pnpm add ... --ignore-minimum-release-age`.
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@taskforcesh/bullmq-pro'


### PR DESCRIPTION
## Summary

Adds `minimumReleaseAgeExclude` to `pnpm-workspace.yaml` so that `@taskforcesh/bullmq-pro` is not blocked by the 7-day cooling-off period.

## Why

`@taskforcesh/bullmq-pro` is a commercial package served from taskforce.sh's private registry (configured in `.npmrc`), not the public npm registry. The supply-chain threat model that `minimumReleaseAge` defends against (typosquats, compromised maintainer accounts on public npm) does not apply. We also want urgent hotfix releases to be installable without manual `--ignore-minimum-release-age` overrides.

Exact package name is used rather than `@taskforcesh/*` so a future addition to that scope is a conscious decision instead of an implicit inheritance of the exemption.

## Changes

- `pnpm-workspace.yaml`: add `minimumReleaseAgeExclude: ['@taskforcesh/bullmq-pro']`. Also drop the descriptive comments above `minimumReleaseAge`; the behavior is documented in `AGENTS.md`.
- `AGENTS.md`: append a sentence noting the exemption.

## Verification

`pnpm install` from the existing lockfile completes cleanly ("Already up to date"). No code touched, no other commands needed.