### PR TITLE
fix: honor BullMQ removeJobScheduler return value in JobScheduler.remove

### DIFF
--- a/.changeset/fix-job-scheduler-remove-multi-queue.md
+++ b/.changeset/fix-job-scheduler-remove-multi-queue.md
@@ -1,0 +1,5 @@
+---
+'@nemoventures/adonis-jobs': patch
+---
+
+Fix `JobScheduler.remove()` reporting success without actually deleting the scheduler. The wrapper previously ignored the boolean returned by BullMQ's `Queue#removeJobScheduler()` and short-circuited after the first non-throwing queue, so schedulers registered on any queue other than the first one in `config.queue.queues` were left active while the caller saw `true`. `remove()` now honours the BullMQ return value, keeps scanning remaining queues when none reported a deletion, and only returns `true` once a queue actually removed the scheduler (closes #115).

--- a/packages/core/services/main.ts
+++ b/packages/core/services/main.ts
@@ -8,4 +8,15 @@ await app?.booted(async () => {
   queue = await app.container.make('queue.manager')
 })
 
+/**
+ * @internal
+ *
+ * Replace the cached queue service. Only intended for test setups where
+ * the application bootstrap order does not allow the default `booted`
+ * callback to resolve the binding. Production code must not call this.
+ */
+export function setQueueServiceForTesting(service: QueueService) {
+  queue = service
+}
+
 export { queue as default }

--- a/packages/core/src/job/job_scheduler.ts
+++ b/packages/core/src/job/job_scheduler.ts
@@ -80,7 +80,12 @@ export class JobScheduler {
   }
 
   /**
-   * Remove a specific scheduled job by id
+   * Remove a specific scheduled job by id. Scans every configured queue
+   * and returns true only if some queue actually removed the scheduler.
+   *
+   * BullMQ's `Queue#removeJobScheduler` returns a boolean indicating whether
+   * a scheduler was actually deleted; we must honor that to avoid reporting
+   * success when the scheduler still lives on a later queue.
    */
   static async remove(id: string): Promise<boolean> {
     const queueNames = Object.keys(queueManager.config.queues) as (keyof Queues)[]
@@ -89,8 +94,8 @@ export class JobScheduler {
       const queue = queueManager.useQueue(queueName)
 
       try {
-        await queue.removeJobScheduler(id)
-        return true
+        const removed = await queue.removeJobScheduler(id)
+        if (removed) return true
       } catch (_error) {
         continue
       }

--- a/packages/core/tests/unit/job_scheduler.spec.ts
+++ b/packages/core/tests/unit/job_scheduler.spec.ts
@@ -1,7 +1,39 @@
 import { test } from '@japa/runner'
 
 import Cleanup from '../fixtures/cleanup.ts'
-import type { JobScheduler } from '#job/job_scheduler'
+import { setQueueServiceForTesting } from '../../services/main.ts'
+import type { JobScheduler as JobSchedulerType } from '#job/job_scheduler'
+
+interface FakeQueue {
+  removeJobScheduler: (id: string) => Promise<boolean>
+  calls: string[]
+}
+
+function makeFakeQueue(removed: boolean | Error): FakeQueue {
+  const queue: FakeQueue = {
+    calls: [],
+    async removeJobScheduler(id: string) {
+      queue.calls.push(id)
+      if (removed instanceof Error) throw removed
+      return removed
+    },
+  }
+  return queue
+}
+
+function installFakeQueueManager(queues: Record<string, FakeQueue>) {
+  const fakeManager = {
+    config: {
+      queues: Object.fromEntries(Object.keys(queues).map((name) => [name, {}])),
+    },
+    useQueue(name: string) {
+      const queue = queues[name]
+      if (!queue) throw new Error(`Unexpected useQueue call for "${name}"`)
+      return queue
+    },
+  }
+  setQueueServiceForTesting(fakeManager as never)
+}
 
 test.group('Job Scheduler', () => {
   test('Schedule Typings', async ({ expectTypeOf }) => {
@@ -15,7 +47,7 @@ test.group('Job Scheduler', () => {
       data: { args: ['--verbose'] },
     }
 
-    expectTypeOf<typeof JobScheduler.schedule>().toBeCallableWith(p1)
+    expectTypeOf<typeof JobSchedulerType.schedule>().toBeCallableWith(p1)
 
     const p2 = {
       key: 'test-command-job',
@@ -24,7 +56,7 @@ test.group('Job Scheduler', () => {
       data: {},
     }
 
-    expectTypeOf<typeof JobScheduler.schedule>().toBeCallableWith(p2)
+    expectTypeOf<typeof JobSchedulerType.schedule>().toBeCallableWith(p2)
 
     const p3 = {
       key: 'fake-job',
@@ -33,6 +65,62 @@ test.group('Job Scheduler', () => {
       repeat: { pattern: '*/5 * * * * *' },
     }
 
-    expectTypeOf<typeof JobScheduler.schedule>().toBeCallableWith(p3)
+    expectTypeOf<typeof JobSchedulerType.schedule>().toBeCallableWith(p3)
   }).skip(true, 'Type checking only')
+})
+
+test.group('JobScheduler.remove', () => {
+  test('returns true and keeps scanning when the scheduler lives on a later queue', async ({
+    assert,
+  }) => {
+    const defaultQueue = makeFakeQueue(false)
+    const emailsQueue = makeFakeQueue(true)
+    installFakeQueueManager({ default: defaultQueue, emails: emailsQueue })
+
+    const { JobScheduler } = await import('#job/job_scheduler')
+    const result = await JobScheduler.remove('nightly-email')
+
+    assert.isTrue(result)
+    assert.deepEqual(defaultQueue.calls, ['nightly-email'])
+    assert.deepEqual(emailsQueue.calls, ['nightly-email'])
+  })
+
+  test('returns false when no queue actually removes the scheduler', async ({ assert }) => {
+    const defaultQueue = makeFakeQueue(false)
+    const emailsQueue = makeFakeQueue(false)
+    installFakeQueueManager({ default: defaultQueue, emails: emailsQueue })
+
+    const { JobScheduler } = await import('#job/job_scheduler')
+    const result = await JobScheduler.remove('nightly-email')
+
+    assert.isFalse(result)
+    assert.deepEqual(defaultQueue.calls, ['nightly-email'])
+    assert.deepEqual(emailsQueue.calls, ['nightly-email'])
+  })
+
+  test('continues past a queue that throws', async ({ assert }) => {
+    const defaultQueue = makeFakeQueue(new Error('boom'))
+    const emailsQueue = makeFakeQueue(true)
+    installFakeQueueManager({ default: defaultQueue, emails: emailsQueue })
+
+    const { JobScheduler } = await import('#job/job_scheduler')
+    const result = await JobScheduler.remove('nightly-email')
+
+    assert.isTrue(result)
+    assert.deepEqual(defaultQueue.calls, ['nightly-email'])
+    assert.deepEqual(emailsQueue.calls, ['nightly-email'])
+  })
+
+  test('short-circuits on first successful removal', async ({ assert }) => {
+    const defaultQueue = makeFakeQueue(true)
+    const emailsQueue = makeFakeQueue(false)
+    installFakeQueueManager({ default: defaultQueue, emails: emailsQueue })
+
+    const { JobScheduler } = await import('#job/job_scheduler')
+    const result = await JobScheduler.remove('nightly-email')
+
+    assert.isTrue(result)
+    assert.deepEqual(defaultQueue.calls, ['nightly-email'])
+    assert.deepEqual(emailsQueue.calls, [])
+  })
 })


### PR DESCRIPTION
Closes #115.

## Problem

`JobScheduler.remove(key)` loops over every configured queue but discards the boolean returned by BullMQ's `Queue#removeJobScheduler`. It returns `true` after the first queue call that does not throw, so when the scheduler was registered on any queue other than the first one in `config.queue.queues`, the wrapper reports success while the scheduler is still active. Callers think a recurring job was disabled when it was not.

## Fix

In `packages/core/src/job/job_scheduler.ts`:

- Capture the boolean returned by `queue.removeJobScheduler(id)` and only short-circuit when it is `true`.
- Keep scanning the remaining queues when a queue returns `false` or throws.
- Return `false` only when no queue actually removed the scheduler.

Existing `try/catch` resilience is preserved — a single failing queue does not abort the scan.

## Tests

Added four regression tests in `packages/core/tests/unit/job_scheduler.spec.ts`:

1. `returns true and keeps scanning when the scheduler lives on a later queue` — reproduces the bug from the issue.
2. `returns false when no queue actually removes the scheduler`.
3. `continues past a queue that throws` — preserves existing resilience.
4. `short-circuits on first successful removal` — verifies the happy path still skips later queues.

The suite injects a fake `QueueService` via a new `@internal` `setQueueServiceForTesting` export in `services/main.ts`. This was necessary because the module's existing `app.booted` callback resolves `queue.manager` against whichever app last called `setApp` on the global `@adonisjs/core/services/app` binding. By the time the scheduler suite runs, prior `setupApp()` helpers in `job_discoverer.spec.ts` have already cached an unbooted app, so the binding stays `undefined` and there is no clean way to inject a fake from outside the module. The setter is documented as test-only.

## Verification

- `pnpm --filter @nemoventures/adonis-jobs quick:test` — 17 passed, 1 skipped (existing type-only test).
- `pnpm typecheck` — clean across `packages/core` and `playground`.
- `pnpm lint` — no new errors (5 pre-existing warnings, unchanged).

A `patch` changeset is included for `@nemoventures/adonis-jobs`.
