### PR TITLE
feat: add optional Workbench UI integration

### DIFF
--- a/.changeset/workbench-ui.md
+++ b/.changeset/workbench-ui.md
@@ -1,0 +1,13 @@
+---
+'@nemoventures/adonis-jobs': minor
+---
+
+Add optional Workbench UI integration as an alternative to QueueDash. Mount it via the new `@nemoventures/adonis-jobs/ui/workbench` subpath export:
+
+```ts
+import { workbenchUiRoutes } from '@nemoventures/adonis-jobs/ui/workbench'
+
+workbenchUiRoutes().prefix('/admin/workbench')
+```
+
+`@getworkbench/core` is declared as an optional peer dependency, so it only needs to be installed by users who opt into the Workbench UI. See the [Workbench Dashboard guide](https://adonis-jobs.nemoventures.dev/guides/workbench-dashboard) for full documentation.

--- a/docs/docs/pages/guides/workbench-dashboard.mdx
+++ b/docs/docs/pages/guides/workbench-dashboard.mdx
@@ -1,0 +1,118 @@
+---
+title: Workbench Dashboard
+description: Set up and use the Workbench UI as an alternative dashboard for monitoring and managing your job queues
+---
+
+# Workbench Dashboard
+
+[Workbench](https://github.com/pontusab/workbench) is a modern open-source BullMQ dashboard with flows/DAG visualization, schedulers, search, and metrics. It is shipped as an **alternative** to the built-in [QueueDash dashboard](/guides/queue-dashboard) — you can use either one (or both) depending on which UI you prefer.
+
+Workbench is delivered as an **optional peer dependency**, so it does not affect install size for users who stick with QueueDash.
+
+## Installation
+
+```bash
+npm i @getworkbench/core
+```
+
+## Setup
+
+Add the dashboard routes to your `start/routes.ts` file:
+
+```typescript
+import router from '@adonisjs/core/services/router'
+import { workbenchUiRoutes } from '@nemoventures/adonis-jobs/ui/workbench'
+
+router.group(() => {
+  workbenchUiRoutes().prefix('/workbench')
+}).prefix('/admin')
+```
+
+This makes the dashboard available at `/admin/workbench`. Run your AdonisJS application and open `http://localhost:3333/admin/workbench` to access it.
+
+Queues are pulled automatically from your `config/queue.ts` — there is no need to pass them explicitly.
+
+## Options
+
+`workbenchUiRoutes(options?)` accepts the following options:
+
+| Option     | Type                              | Description                                                                |
+| ---------- | --------------------------------- | -------------------------------------------------------------------------- |
+| `title`    | `string`                          | Dashboard title shown in the nav bar. Defaults to `"Workbench"`.           |
+| `logo`     | `string`                          | URL of a logo image displayed in the nav.                                  |
+| `readonly` | `boolean`                         | When `true`, all mutating actions (retry, remove, promote) return 403.     |
+| `tags`     | `string[]`                        | Fields from `job.data` to extract as filterable tags in the UI.            |
+| `auth`     | `{ username, password }`          | Built-in HTTP basic-auth credentials. See [Authentication](#authentication). |
+
+Example:
+
+```typescript
+workbenchUiRoutes({
+  title: 'Background Jobs',
+  readonly: env.get('NODE_ENV') === 'production',
+  tags: ['userId', 'tenantId'],
+}).prefix('/admin/workbench')
+```
+
+## Authentication
+
+### Recommended: AdonisJS middleware
+
+Because the dashboard returns a standard AdonisJS `RouteGroup`, the cleanest way to protect it is by wrapping it with the framework's own middleware:
+
+```typescript
+import { middleware } from '#start/kernel'
+
+router.group(() => {
+  workbenchUiRoutes().prefix('/workbench')
+})
+  .prefix('/admin')
+  .use(middleware.auth({ guards: ['basicAuth'] }))
+```
+
+### Alternative: built-in basic auth
+
+Workbench also ships its own HTTP basic-auth gate. Pass credentials via the `auth` option:
+
+```typescript
+workbenchUiRoutes({
+  auth: {
+    username: env.get('WORKBENCH_USER'),
+    password: env.get('WORKBENCH_PASS'),
+  },
+}).prefix('/admin/workbench')
+```
+
+The built-in gate is convenient if you don't already have an auth setup, but the AdonisJS middleware approach integrates better with the rest of your application (sessions, guards, RBAC, etc.).
+
+## Shield Configuration
+
+The dashboard performs `POST` requests for actions like retry, remove, and promote. Exempt the dashboard routes from [CSRF protection](https://docs.adonisjs.com/guides/security/securing-ssr-applications#config-reference) in your `config/shield.ts`:
+
+```typescript
+csrf: {
+  enabled: true,
+  exceptRoutes: (ctx) => {
+    return ctx.request.url().startsWith('/admin/workbench')
+  },
+},
+```
+
+## QueueDash vs Workbench
+
+Both dashboards are first-party integrations. Pick whichever fits your taste — they both target the same BullMQ feature surface.
+
+- **QueueDash** is bundled by default with `@nemoventures/adonis-jobs`. Lightweight, mature, and battle-tested.
+- **Workbench** is opt-in. Newer, ships a richer UI (flows/DAG view, tag-based filtering, search), and follows a more modern design language.
+
+Nothing stops you from mounting both side-by-side at different prefixes during evaluation.
+
+## How the integration works
+
+`workbenchUiRoutes()` is a thin shim over [`@getworkbench/core`](https://www.npmjs.com/package/@getworkbench/core)'s `createFetchHandler`. The dashboard is internally a [Hono](https://hono.dev) app exposed as a Fetch-compatible handler; this package translates the AdonisJS request/response pair into a web-standard `Request`/`Response` and back, automatically pulling queues from your `config/queue.ts`.
+
+The official [`@getworkbench/adonis`](https://www.npmjs.com/package/@getworkbench/adonis) package offers a different ergonomic (you pass queues and the mount path explicitly to `mountWorkbench(router, '/jobs', { queues, … })`). Use that one directly if you prefer to manage the queue list yourself or want to bypass the queue manager.
+
+## Next Steps
+
+Learn about [monitoring and metrics](/guides/observability) to set up comprehensive observability for your job queues.

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -63,6 +63,10 @@ export default defineConfig({
           link: '/guides/queue-dashboard',
         },
         {
+          text: 'Workbench Dashboard',
+          link: '/guides/workbench-dashboard',
+        },
+        {
           text: 'Observability',
           link: '/guides/observability',
         },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "@adonisjs/core": "catalog:",
     "@adonisjs/http-server": "^9.0.0",
     "@adonisjs/redis": "^10.0.0",
-    "@getworkbench/core": "^0.6.0",
+    "@getworkbench/core": "^0.9.1",
     "@japa/assert": "^4.2.0",
     "@japa/expect": "^3.0.7",
     "@japa/expect-type": "^2.0.4",
@@ -86,7 +86,7 @@
     "@adonisjs/core": "^7.0.0",
     "@adonisjs/http-server": "^8.0.0 || ^9.0.0",
     "@adonisjs/redis": "^10.0.0",
-    "@getworkbench/core": "^0.6.0",
+    "@getworkbench/core": "^0.9.1",
     "@julr/adonisjs-prometheus": "^2.0.0",
     "@taskforcesh/bullmq-pro": "^7.35.2",
     "bullmq": "^5.53.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,15 +5,15 @@
   "keywords": [
     "adonis",
     "adonisjs",
-    "queue",
-    "queues",
-    "jobs",
     "background-jobs",
     "bullmq",
+    "jobs",
+    "queue",
+    "queues",
     "redis",
     "scheduler",
-    "worker",
-    "typescript"
+    "typescript",
+    "worker"
   ],
   "license": "MIT",
   "repository": "https://github.com/nemoengineering/adonis-jobs",
@@ -36,7 +36,8 @@
     "./queue_provider": "./build/providers/queue_provider.js",
     "./metrics": "./build/src/metrics/index.js",
     "./services/main": "./build/services/main.js",
-    "./ui/queuedash": "./build/src/ui/queuedash/index.js"
+    "./ui/queuedash": "./build/src/ui/queuedash/index.js",
+    "./ui/workbench": "./build/src/ui/workbench/index.js"
   },
   "publishConfig": {
     "access": "public"
@@ -67,6 +68,7 @@
     "@adonisjs/core": "catalog:",
     "@adonisjs/http-server": "^9.0.0",
     "@adonisjs/redis": "^10.0.0",
+    "@getworkbench/core": "^0.6.0",
     "@japa/assert": "^4.2.0",
     "@japa/expect": "^3.0.7",
     "@japa/expect-type": "^2.0.4",
@@ -84,11 +86,15 @@
     "@adonisjs/core": "^7.0.0",
     "@adonisjs/http-server": "^8.0.0 || ^9.0.0",
     "@adonisjs/redis": "^10.0.0",
+    "@getworkbench/core": "^0.6.0",
     "@julr/adonisjs-prometheus": "^2.0.0",
     "@taskforcesh/bullmq-pro": "^7.35.2",
     "bullmq": "^5.53.2"
   },
   "peerDependenciesMeta": {
+    "@getworkbench/core": {
+      "optional": true
+    },
     "@julr/adonisjs-prometheus": {
       "optional": true
     },

--- a/packages/core/src/ui/workbench/index.ts
+++ b/packages/core/src/ui/workbench/index.ts
@@ -1,0 +1,174 @@
+import type { RouteGroup } from '@adonisjs/http-server'
+import router from '@adonisjs/core/services/router'
+
+import type { Queues } from '../../types/index.ts'
+import queueManager from '../../../services/main.ts'
+
+/**
+ * Public options exposed by the Workbench wrapper. We omit `queues` (filled in
+ * from the Adonis-level queue config) and `basePath` (derived from the matched
+ * route pattern at request time) because those are wired by the framework, not
+ * by user input.
+ *
+ * Typed loosely to avoid a hard import of `@getworkbench/core` at type-resolution
+ * time — the package is an optional peer dep and may not be installed.
+ */
+export interface WorkbenchUiOptions {
+  /**
+   * Optional basic-auth credentials. When set, Workbench's built-in auth gate
+   * runs before any handler. Most Adonis users will prefer to skip this and
+   * wrap the route group with the framework's own `middleware.auth(...)`.
+   */
+  auth?: { username: string; password: string }
+  /** Dashboard title shown in the nav bar. Defaults to `"Workbench"`. */
+  title?: string
+  /** Logo URL displayed in the nav bar. */
+  logo?: string
+  /** When true, mutating endpoints (retry, remove, promote, pause, …) return 403. */
+  readonly?: boolean
+  /** Fields from `job.data` to extract as filterable tags in the UI. */
+  tags?: string[]
+}
+
+type WorkbenchModule = typeof import('@getworkbench/core')
+type FetchHandler = ReturnType<WorkbenchModule['createFetchHandler']>['fetch']
+
+let workbenchModulePromise: Promise<WorkbenchModule> | undefined
+
+/**
+ * Dynamically load `@getworkbench/core`. It is declared as an optional peer
+ * dependency so users who stick with the QueueDash UI don't pay the install
+ * cost (Workbench ships React/Radix/Recharts/etc — ~1.7MB unpacked).
+ */
+async function loadWorkbench(): Promise<WorkbenchModule> {
+  if (!workbenchModulePromise) {
+    workbenchModulePromise = import('@getworkbench/core').catch((err) => {
+      workbenchModulePromise = undefined
+      throw new Error(
+        '[adonis-jobs] @getworkbench/core is not installed. Run `npm i @getworkbench/core` to use the Workbench UI.',
+        { cause: err },
+      )
+    })
+  }
+  return workbenchModulePromise
+}
+
+/**
+ * Mount the Workbench BullMQ dashboard as an AdonisJS route group.
+ *
+ * Queues are pulled from your `config/queue.ts` via the QueueManager — you
+ * don't need to pass them in. The mount prefix is whatever you chain
+ * `.prefix(...)` onto the returned `RouteGroup`.
+ *
+ * Internally, this thin shim delegates to `@getworkbench/core`'s
+ * `createFetchHandler`, which exposes the dashboard as a Fetch-compatible
+ * handler. We translate the Adonis request/response pair into a web `Request`
+ * (streaming the raw Node `IncomingMessage` as the body for non-GET/HEAD) and
+ * back. All routing, auth, CORS, static assets, and HTML shell rendering live
+ * upstream — we just bridge the two transport layers.
+ *
+ * @example
+ * ```ts
+ * // start/routes.ts
+ * import { workbenchUiRoutes } from '@nemoventures/adonis-jobs/ui/workbench'
+ *
+ * workbenchUiRoutes().prefix('/admin/workbench')
+ * ```
+ *
+ * @example Built-in basic auth
+ * ```ts
+ * workbenchUiRoutes({
+ *   auth: { username: env.get('WB_USER'), password: env.get('WB_PASS') },
+ * }).prefix('/admin/workbench')
+ * ```
+ *
+ * @example Adonis middleware (recommended)
+ * ```ts
+ * router.group(() => {
+ *   workbenchUiRoutes().prefix('/workbench')
+ * })
+ *   .prefix('/admin')
+ *   .use(middleware.auth({ guards: ['basicAuth'] }))
+ * ```
+ */
+export function workbenchUiRoutes(options: WorkbenchUiOptions = {}): RouteGroup {
+  // Memoize `{ fetch }` per resolved basePath. Adonis routers normally produce
+  // a single concrete pattern per registered handler, so this map will only
+  // ever hold one entry in practice — keying by basePath just makes us robust
+  // if a user somehow mounts the same group at multiple prefixes.
+  const handlerByBase = new Map<string, FetchHandler>()
+
+  async function getFetchHandler(basePath: string): Promise<FetchHandler> {
+    const cached = handlerByBase.get(basePath)
+    if (cached) return cached
+
+    const wb = await loadWorkbench()
+    const queues = Object.keys(queueManager.config.queues).map(
+      (name) => queueManager.useQueue(name as keyof Queues) as any,
+    )
+
+    const { fetch } = wb.createFetchHandler({
+      ...options,
+      queues,
+      basePath,
+    })
+    handlerByBase.set(basePath, fetch)
+    return fetch
+  }
+
+  /**
+   * Derive Workbench's `basePath` from the matched Adonis route. The wildcard
+   * route registers as `<prefix>/*`; the bare-root route as `<prefix>`. In both
+   * cases we want the prefix without trailing slash or wildcard.
+   */
+  function basePathFromPattern(pattern: string | undefined): string {
+    if (!pattern) return '/'
+    let p = pattern
+    if (p.endsWith('/*')) p = p.slice(0, -2)
+    if (p.endsWith('/') && p.length > 1) p = p.slice(0, -1)
+    return p || '/'
+  }
+
+  async function handle(ctx: import('@adonisjs/core/http').HttpContext) {
+    const { request, response, route } = ctx
+    const basePath = basePathFromPattern(route?.pattern)
+    const fetch = await getFetchHandler(basePath)
+
+    // Build a web-standard Request from the Adonis HTTP context.
+    const url = request.completeUrl(true)
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(request.headers())) {
+      if (typeof value === 'string') {
+        headers.set(key, value)
+      } else if (Array.isArray(value)) {
+        for (const entry of value) headers.append(key, entry)
+      }
+    }
+
+    const method = request.method()
+    const init: Record<string, unknown> = { method, headers }
+    if (method !== 'GET' && method !== 'HEAD') {
+      // Stream the raw Node IncomingMessage. `duplex: 'half'` is mandatory in
+      // Node 18+ when passing a ReadableStream or Node stream as the body.
+      init.duplex = 'half'
+      init.body = request.request
+    }
+
+    const webResponse = await fetch(new Request(url, init as RequestInit))
+
+    response.status(webResponse.status)
+    webResponse.headers.forEach((value, key) => {
+      // `content-length` is reset by Adonis based on the actual buffer length.
+      if (key.toLowerCase() === 'content-length') return
+      response.header(key, value)
+    })
+    response.send(Buffer.from(await webResponse.arrayBuffer()))
+  }
+
+  return router.group(() => {
+    // Two routes: the bare mount and a wildcard catch-all. Both delegate to
+    // the same handler — Workbench's internal Hono router does the rest.
+    router.any('/', handle)
+    router.any('/*', handle)
+  })
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -34,6 +34,7 @@
     "@adonisjs/cors": "^3.0.0",
     "@adonisjs/redis": "^10.0.0",
     "@adonisjs/static": "^2.0.1",
+    "@getworkbench/core": "^0.6.0",
     "@julr/adonisjs-prometheus": "^2.1.0",
     "@nemoventures/adonis-jobs": "workspace:*",
     "@opentelemetry/auto-instrumentations-node": "^0.71.0",

--- a/playground/package.json
+++ b/playground/package.json
@@ -34,7 +34,7 @@
     "@adonisjs/cors": "^3.0.0",
     "@adonisjs/redis": "^10.0.0",
     "@adonisjs/static": "^2.0.1",
-    "@getworkbench/core": "^0.6.0",
+    "@getworkbench/core": "^0.9.1",
     "@julr/adonisjs-prometheus": "^2.1.0",
     "@nemoventures/adonis-jobs": "workspace:*",
     "@opentelemetry/auto-instrumentations-node": "^0.71.0",

--- a/playground/start/routes.ts
+++ b/playground/start/routes.ts
@@ -10,6 +10,7 @@
 import router from '@adonisjs/core/services/router'
 import CommandJob from '@nemoventures/adonis-jobs/builtin/command_job'
 import { queueDashUiRoutes } from '@nemoventures/adonis-jobs/ui/queuedash'
+import { workbenchUiRoutes } from '@nemoventures/adonis-jobs/ui/workbench'
 import { BulkDispatcher, JobChain, JobFlow, JobScheduler } from '@nemoventures/adonis-jobs'
 
 import SlowJob from '#jobs/slow_job'
@@ -200,3 +201,4 @@ router.get('/dedup-throttle', async () => {
 })
 
 queueDashUiRoutes().prefix('/admin/queue')
+workbenchUiRoutes().prefix('/admin/workbench')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@adonisjs/core@7.3.3(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@vinejs/vine@4.3.0)(edge.js@6.5.0)(pino-pretty@13.1.3)(youch@4.1.0-beta.13))
       '@getworkbench/core':
-        specifier: ^0.6.0
-        version: 0.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.9.1
+        version: 0.9.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@japa/assert':
         specifier: ^4.2.0
         version: 4.2.0(@japa/runner@5.3.0)
@@ -170,8 +170,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@adonisjs/core@7.3.3(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@vinejs/vine@4.3.0)(edge.js@6.5.0)(pino-pretty@13.1.3)(youch@4.1.0-beta.13))
       '@getworkbench/core':
-        specifier: ^0.6.0
-        version: 0.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.9.1
+        version: 0.9.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@julr/adonisjs-prometheus':
         specifier: ^2.1.0
         version: 2.1.0(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@adonisjs/core@7.3.3(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@vinejs/vine@4.3.0)(edge.js@6.5.0)(pino-pretty@13.1.3)(youch@4.1.0-beta.13))(@opentelemetry/api@1.9.0)(bentocache@1.6.0(ioredis@5.9.3))
@@ -1104,8 +1104,8 @@ packages:
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
 
-  '@getworkbench/core@0.6.0':
-    resolution: {integrity: sha512-81SqZN//L1K9FjpUn9x6pzdobbHZ1uBxXBHjOo/vBqYLaDQEdo7kfqtpgPbAZbknvM6hhMOi+ttyNAKz9oEBug==}
+  '@getworkbench/core@0.9.1':
+    resolution: {integrity: sha512-5HVBVLCV8JOlPrXgs00R9670/gYU87g44MtsLqRchhX36fWCGucflym/qkgQVw1xg2viRTqip1QFTJFsoxrDew==}
     engines: {node: '>=18'}
     peerDependencies:
       bullmq: '>=5.0.0'
@@ -8590,7 +8590,7 @@ snapshots:
 
   '@fortawesome/fontawesome-free@6.7.2': {}
 
-  '@getworkbench/core@0.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@getworkbench/core@0.9.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@adonisjs/redis':
         specifier: ^10.0.0
         version: 10.0.0(@adonisjs/core@7.3.3(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@vinejs/vine@4.3.0)(edge.js@6.5.0)(pino-pretty@13.1.3)(youch@4.1.0-beta.13))
+      '@getworkbench/core':
+        specifier: ^0.6.0
+        version: 0.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@japa/assert':
         specifier: ^4.2.0
         version: 4.2.0(@japa/runner@5.3.0)
@@ -166,6 +169,9 @@ importers:
       '@adonisjs/static':
         specifier: ^2.0.1
         version: 2.0.1(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@adonisjs/core@7.3.3(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@vinejs/vine@4.3.0)(edge.js@6.5.0)(pino-pretty@13.1.3)(youch@4.1.0-beta.13))
+      '@getworkbench/core':
+        specifier: ^0.6.0
+        version: 0.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@julr/adonisjs-prometheus':
         specifier: ^2.1.0
         version: 2.1.0(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@adonisjs/core@7.3.3(@adonisjs/assembler@8.1.0(typescript@5.9.3))(@vinejs/vine@4.3.0)(edge.js@6.5.0)(pino-pretty@13.1.3)(youch@4.1.0-beta.13))(@opentelemetry/api@1.9.0)(bentocache@1.6.0(ioredis@5.9.3))
@@ -1097,6 +1103,13 @@ packages:
   '@fortawesome/fontawesome-free@6.7.2':
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
+
+  '@getworkbench/core@0.6.0':
+    resolution: {integrity: sha512-81SqZN//L1K9FjpUn9x6pzdobbHZ1uBxXBHjOo/vBqYLaDQEdo7kfqtpgPbAZbknvM6hhMOi+ttyNAKz9oEBug==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      bullmq: '>=5.0.0'
+      ioredis: '>=5.0.0'
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -2269,6 +2282,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-accessible-icon@1.1.7':
     resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
     peerDependencies:
@@ -2349,6 +2365,19 @@ packages:
 
   '@radix-ui/react-checkbox@1.3.2':
     resolution: {integrity: sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2452,6 +2481,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.1.15':
     resolution: {integrity: sha512-mIBnOjgwo9AH3FyKaSWoSu/dYj6VdhJ7frEPiGTeXCdUFHjl9h3mFh2wwhEtINOmYXWhdpf1rY2minFsmaNgVQ==}
     peerDependencies:
@@ -2502,6 +2544,19 @@ packages:
 
   '@radix-ui/react-hover-card@1.1.14':
     resolution: {integrity: sha512-CPYZ24Mhirm+g6D8jArmLzjYu4Eyg3TTUHswR26QgzXBHBe64BO/RHOJKzmF/Dxb4y4f9PKyJdwm/O/AhNkb+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2631,6 +2686,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -2646,6 +2714,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.4':
     resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3831,6 +3912,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
 
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -4118,6 +4208,9 @@ packages:
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
   cli-boxes@4.0.1:
     resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
@@ -4438,6 +4531,9 @@ packages:
 
   dagre-d3-es@7.0.11:
     resolution: {integrity: sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==}
+
+  dagre@0.8.5:
+    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -4939,6 +5035,20 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -5055,6 +5165,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphlib@2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
@@ -5661,8 +5774,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.5:
-    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
+  lru-cache@11.4.0:
+    resolution: {integrity: sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -5964,6 +6077,12 @@ packages:
 
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -7279,11 +7398,6 @@ packages:
       '@types/react':
         optional: true
 
-  use-sync-external-store@1.5.0:
-    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -7565,6 +7679,21 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8443,6 +8572,12 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
+  '@floating-ui/react-dom@2.1.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/dom': 1.7.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@floating-ui/react@0.27.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -8454,6 +8589,25 @@ snapshots:
   '@floating-ui/utils@0.2.9': {}
 
   '@fortawesome/fontawesome-free@6.7.2': {}
+
+  '@getworkbench/core@0.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(bullmq@5.71.0)(immer@11.1.8)(ioredis@5.9.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@xyflow/react': 12.10.2(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      bullmq: 5.71.0
+      dagre: 0.8.5
+      framer-motion: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      hono: 4.7.11
+      ioredis: 5.9.3
+      lru-cache: 11.4.0
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - immer
+      - react
+      - react-dom
 
   '@grpc/grpc-js@1.14.3':
     dependencies:
@@ -9798,6 +9952,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -9847,6 +10003,15 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -9885,6 +10050,22 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-collapsible@1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -9919,6 +10100,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-context-menu@2.2.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -9938,6 +10125,12 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-dialog@1.1.14(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -9979,6 +10172,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-dropdown-menu@2.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -10042,6 +10248,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-icons@1.3.2(react@19.1.0)':
     dependencies:
@@ -10206,6 +10429,24 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -10215,6 +10456,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-presence@1.1.4(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -10226,6 +10477,16 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
@@ -10234,6 +10495,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -10361,6 +10631,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-switch@1.2.5(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -10479,6 +10756,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.8)(react@19.1.0)
@@ -10487,12 +10770,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
@@ -10501,10 +10799,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       react: 19.1.0
-      use-sync-external-store: 1.5.0(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.8
 
@@ -10514,11 +10819,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
@@ -10527,12 +10844,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11204,6 +11535,11 @@ snapshots:
       '@types/react': 19.1.8
     optional: true
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+    optional: true
+
   '@types/react@19.1.8':
     dependencies:
       csstype: 3.1.3
@@ -11411,6 +11747,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abstract-logging@2.0.1: {}
 
   acorn-import-attributes@1.9.5(acorn@8.15.0):
@@ -11518,7 +11877,7 @@ snapshots:
       '@julr/utils': 1.9.0
       '@poppinss/exception': 1.2.3
       async-mutex: 0.5.0
-      lru-cache: 11.2.5
+      lru-cache: 11.4.0
       p-timeout: 7.0.1
     optionalDependencies:
       ioredis: 5.9.3
@@ -11679,6 +12038,8 @@ snapshots:
   ci-info@4.2.0: {}
 
   cjs-module-lexer@2.2.0: {}
+
+  classcat@5.0.5: {}
 
   cli-boxes@4.0.1: {}
 
@@ -12018,6 +12379,11 @@ snapshots:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.17.21
+
+  dagre@0.8.5:
+    dependencies:
+      graphlib: 2.1.8
+      lodash: 4.17.21
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -12540,6 +12906,15 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  framer-motion@12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
@@ -12659,6 +13034,10 @@ snapshots:
   google-logging-utils@1.1.3: {}
 
   graceful-fs@4.2.11: {}
+
+  graphlib@2.1.8:
+    dependencies:
+      lodash: 4.17.21
 
   hachure-fill@0.5.2: {}
 
@@ -12832,7 +13211,7 @@ snapshots:
 
   hosted-git-info@9.0.2:
     dependencies:
-      lru-cache: 11.2.5
+      lru-cache: 11.4.0
 
   hot-hook@1.0.0:
     dependencies:
@@ -13282,7 +13661,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.5: {}
+  lru-cache@11.4.0: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -13884,6 +14263,12 @@ snapshots:
       dompurify: 3.2.7
       marked: 14.0.0
 
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
   mri@1.2.0: {}
 
   ms@2.0.0: {}
@@ -14147,7 +14532,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.5
+      lru-cache: 11.4.0
       minipass: 7.1.3
 
   path-type@4.0.0: {}
@@ -15422,7 +15807,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
-  use-sync-external-store@1.5.0(react@19.1.0):
+  use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:
       react: 19.1.0
 
@@ -15745,5 +16130,13 @@ snapshots:
       youch-core: 0.3.3
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.8
+      react: 19.2.6
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,5 @@ catalog:
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@taskforcesh/bullmq-pro'
+  - '@getworkbench/core'
   - '@adonisjs/*'


### PR DESCRIPTION
## Summary

Adds an optional second BullMQ dashboard alongside the existing QueueDash integration. Mount it via the new subpath export:

```ts
import { workbenchUiRoutes } from '@nemoventures/adonis-jobs/ui/workbench'

workbenchUiRoutes().prefix('/admin/workbench')
```

`@getworkbench/core` is declared as an **optional peer dependency**, so users who stay on QueueDash pay no install cost.

## How it works

Thin (~170 LOC) shim over [`@getworkbench/core`](https://github.com/pontusab/workbench)'s `createFetchHandler`. The dashboard is internally a [Hono](https://hono.dev) app exposed as a Fetch-compatible handler; this package translates the AdonisJS request/response pair into a web-standard `Request`/`Response` and back, auto-filling queues from `config/queue.ts`.

The raw Node `IncomingMessage` is streamed as the request body for non-GET/HEAD requests (matches the official `@getworkbench/adonis` adapter), so AdonisJS's BodyParser is bypassed for the dashboard.

## Changes

- **New**: `packages/core/src/ui/workbench/index.ts` — `workbenchUiRoutes(options?)` factory.
- **New**: subpath export `@nemoventures/adonis-jobs/ui/workbench`.
- **New**: optional peer dep `@getworkbench/core@^0.6.0` (also added to `minimumReleaseAgeExclude` since releases are <7 days old).
- **New**: `docs/docs/pages/guides/workbench-dashboard.mdx` + sidebar entry.
- **Playground**: mounts Workbench at `/admin/workbench` alongside QueueDash at `/admin/queue`.

## Verification

- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format` — all green.
- QueueDash integration untouched (no regressions expected).
- Friendly error fires when `@getworkbench/core` is missing (dynamic import wrapped in try/catch).

## Manual testing

```bash
docker compose -f playground/compose.yml up -d redis
pnpm --filter @nemoventures/adonis-jobs build
pnpm --filter playground dev
```

Then visit:
- http://localhost:3333/admin/workbench
- http://localhost:3333/admin/queue (regression check)

## Changeset

Included (`minor` bump). See `.changeset/workbench-ui.md`.