### PR TITLE
refactor: add route names inside`queueDashUiRoutes`

### DIFF
--- a/packages/core/src/ui/queuedash/index.ts
+++ b/packages/core/src/ui/queuedash/index.ts
@@ -15,68 +15,78 @@ export function queueDashUiRoutes(): RouteGroup {
   const style = readFileSync(fileURLToPath(import.meta.resolve('@queuedash/ui/dist/styles.css')))
 
   return router.group(() => {
-    router.any('/trpc/*', async ({ request, response }) => {
-      const path = request.url().split('/trpc/')[1]
-      const url = new URL(request.completeUrl(true))
+    router
+      .any('/trpc/*', async ({ request, response }) => {
+        const path = request.url().split('/trpc/')[1]
+        const url = new URL(request.completeUrl(true))
 
-      const queues = queueManager.config.queues
+        const queues = queueManager.config.queues
 
-      const req = new Request(url, {
-        headers: request.headers() as any,
-        body: request.raw(),
-        method: request.method(),
+        const req = new Request(url, {
+          headers: request.headers() as any,
+          body: request.raw(),
+          method: request.method(),
+        })
+
+        const trpcResponse = await resolveResponse({
+          createContext: async () => ({
+            queues: Object.keys(queues).reduce(
+              (acc, queueName) => {
+                acc.push({
+                  queue: queueManager.useQueue(queueName as keyof Queues),
+                  displayName: queueName,
+                  type: 'bullmq' as const,
+                })
+
+                return acc
+              },
+              [] as Context['queues'],
+            ),
+          }),
+          router: appRouter,
+          path,
+          req,
+          error: null,
+        })
+
+        const trpcResponseText = await trpcResponse.text()
+
+        trpcResponse.headers.forEach((value, key) => {
+          response.header(key, value)
+        })
+
+        response.status(trpcResponse.status)
+        response.send(trpcResponseText)
       })
+      .as('trpc.*')
 
-      const trpcResponse = await resolveResponse({
-        createContext: async () => ({
-          queues: Object.keys(queues).reduce(
-            (acc, queueName) => {
-              acc.push({
-                queue: queueManager.useQueue(queueName as keyof Queues),
-                displayName: queueName,
-                type: 'bullmq' as const,
-              })
-
-              return acc
-            },
-            [] as Context['queues'],
-          ),
-        }),
-        router: appRouter,
-        path,
-        req,
-        error: null,
+    router
+      .get('main.mjs', async ({ response }) => {
+        response.type('application/javascript').send(mainJS)
       })
+      .as('main.mjs')
 
-      const trpcResponseText = await trpcResponse.text()
-
-      trpcResponse.headers.forEach((value, key) => {
-        response.header(key, value)
+    router
+      .get('styles.css', async ({ response }) => {
+        response.type('text/css').send(style)
       })
+      .as('styles.css')
 
-      response.status(trpcResponse.status)
-      response.send(trpcResponseText)
-    })
+    router
+      .get('/', ({ response, route }) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+        const baseUrl = router.builder().params(route?.meta?.params).make(route?.pattern!)
+        response.type('text/html').send(createQueueDashHtml(baseUrl))
+      })
+      .as('index')
 
-    router.get('main.mjs', async ({ response }) => {
-      response.type('application/javascript').send(mainJS)
-    })
+    router
+      .get('/*', ({ response, route }) => {
+        const patternWithoutWildcard = route?.pattern.slice(0, -2)
+        const baseUrl = router.builder().params(route?.meta?.params).make(patternWithoutWildcard!)
 
-    router.get('styles.css', async ({ response }) => {
-      response.type('text/css').send(style)
-    })
-
-    router.get('/', ({ response, route }) => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-      const baseUrl = router.builder().params(route?.meta?.params).make(route?.pattern!)
-      response.type('text/html').send(createQueueDashHtml(baseUrl))
-    })
-
-    router.get('/*', ({ response, route }) => {
-      const patternWithoutWildcard = route?.pattern.slice(0, -2)
-      const baseUrl = router.builder().params(route?.meta?.params).make(patternWithoutWildcard!)
-
-      response.type('text/html').send(createQueueDashHtml(baseUrl))
-    })
+        response.type('text/html').send(createQueueDashHtml(baseUrl))
+      })
+      .as('*')
   })
 }


### PR DESCRIPTION
Add route names inside the `queueDashUiRoutes` function.
This allows the group to be named. Right now, this code throws an error:

```ts
queueDashUiRoutes().prefix('/jobs').as('jobs')

> RuntimeException: Routes inside a group must have names before calling "router.group.as"
```

The route group inside `queueDashUiRoutes` could also be named, for example `router.group(...).as('queuedash')`.
However, since the function returns the group, it can be named like this: `queueDashUiRoutes().as('jobs')`, so I am not sure this would be useful.