### PR TITLE
refactor: cleaner route names in queueDashUiRoutes + changeset

### DIFF
--- a/.changeset/queuedash-route-names.md
+++ b/.changeset/queuedash-route-names.md
@@ -1,0 +1,5 @@
+---
+'@nemoventures/adonis-jobs': patch
+---
+
+Name the routes registered inside `queueDashUiRoutes()` so the returned group can be named or prefixed-and-named by consumers (e.g. `queueDashUiRoutes().prefix('/jobs').as('jobs')`). Previously this threw `RuntimeException: Routes inside a group must have names before calling "router.group.as"`.

--- a/.changeset/queuedash-route-names.md
+++ b/.changeset/queuedash-route-names.md
@@ -3,3 +3,5 @@
 ---
 
 Name the routes registered inside `queueDashUiRoutes()` so the returned group can be named or prefixed-and-named by consumers (e.g. `queueDashUiRoutes().prefix('/jobs').as('jobs')`). Previously this threw `RuntimeException: Routes inside a group must have names before calling "router.group.as"`.
+
+The routes are self-namespaced under `queuedash.*` (e.g. `queuedash.index`, `queuedash.trpc`) to avoid collisions with application routes. If you additionally name the group, the names stack via prepend — `queueDashUiRoutes().as('jobs')` produces `jobs.queuedash.index`, etc.

--- a/packages/core/src/ui/queuedash/index.ts
+++ b/packages/core/src/ui/queuedash/index.ts
@@ -58,19 +58,19 @@ export function queueDashUiRoutes(): RouteGroup {
         response.status(trpcResponse.status)
         response.send(trpcResponseText)
       })
-      .as('trpc.*')
+      .as('trpc')
 
     router
       .get('main.mjs', async ({ response }) => {
         response.type('application/javascript').send(mainJS)
       })
-      .as('main.mjs')
+      .as('main')
 
     router
       .get('styles.css', async ({ response }) => {
         response.type('text/css').send(style)
       })
-      .as('styles.css')
+      .as('styles')
 
     router
       .get('/', ({ response, route }) => {
@@ -87,6 +87,6 @@ export function queueDashUiRoutes(): RouteGroup {
 
         response.type('text/html').send(createQueueDashHtml(baseUrl))
       })
-      .as('*')
+      .as('catchAll')
   })
 }

--- a/packages/core/src/ui/queuedash/index.ts
+++ b/packages/core/src/ui/queuedash/index.ts
@@ -14,79 +14,81 @@ export function queueDashUiRoutes(): RouteGroup {
   const mainJS = readFileSync(fileURLToPath(import.meta.resolve('@queuedash/client/dist/main.mjs')))
   const style = readFileSync(fileURLToPath(import.meta.resolve('@queuedash/ui/dist/styles.css')))
 
-  return router.group(() => {
-    router
-      .any('/trpc/*', async ({ request, response }) => {
-        const path = request.url().split('/trpc/')[1]
-        const url = new URL(request.completeUrl(true))
+  return router
+    .group(() => {
+      router
+        .any('/trpc/*', async ({ request, response }) => {
+          const path = request.url().split('/trpc/')[1]
+          const url = new URL(request.completeUrl(true))
 
-        const queues = queueManager.config.queues
+          const queues = queueManager.config.queues
 
-        const req = new Request(url, {
-          headers: request.headers() as any,
-          body: request.raw(),
-          method: request.method(),
+          const req = new Request(url, {
+            headers: request.headers() as any,
+            body: request.raw(),
+            method: request.method(),
+          })
+
+          const trpcResponse = await resolveResponse({
+            createContext: async () => ({
+              queues: Object.keys(queues).reduce(
+                (acc, queueName) => {
+                  acc.push({
+                    queue: queueManager.useQueue(queueName as keyof Queues),
+                    displayName: queueName,
+                    type: 'bullmq' as const,
+                  })
+
+                  return acc
+                },
+                [] as Context['queues'],
+              ),
+            }),
+            router: appRouter,
+            path,
+            req,
+            error: null,
+          })
+
+          const trpcResponseText = await trpcResponse.text()
+
+          trpcResponse.headers.forEach((value, key) => {
+            response.header(key, value)
+          })
+
+          response.status(trpcResponse.status)
+          response.send(trpcResponseText)
         })
+        .as('trpc')
 
-        const trpcResponse = await resolveResponse({
-          createContext: async () => ({
-            queues: Object.keys(queues).reduce(
-              (acc, queueName) => {
-                acc.push({
-                  queue: queueManager.useQueue(queueName as keyof Queues),
-                  displayName: queueName,
-                  type: 'bullmq' as const,
-                })
-
-                return acc
-              },
-              [] as Context['queues'],
-            ),
-          }),
-          router: appRouter,
-          path,
-          req,
-          error: null,
+      router
+        .get('main.mjs', async ({ response }) => {
+          response.type('application/javascript').send(mainJS)
         })
+        .as('main')
 
-        const trpcResponseText = await trpcResponse.text()
-
-        trpcResponse.headers.forEach((value, key) => {
-          response.header(key, value)
+      router
+        .get('styles.css', async ({ response }) => {
+          response.type('text/css').send(style)
         })
+        .as('styles')
 
-        response.status(trpcResponse.status)
-        response.send(trpcResponseText)
-      })
-      .as('trpc')
+      router
+        .get('/', ({ response, route }) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+          const baseUrl = router.builder().params(route?.meta?.params).make(route?.pattern!)
+          response.type('text/html').send(createQueueDashHtml(baseUrl))
+        })
+        .as('index')
 
-    router
-      .get('main.mjs', async ({ response }) => {
-        response.type('application/javascript').send(mainJS)
-      })
-      .as('main')
+      router
+        .get('/*', ({ response, route }) => {
+          const patternWithoutWildcard = route?.pattern.slice(0, -2)
+          const baseUrl = router.builder().params(route?.meta?.params).make(patternWithoutWildcard!)
 
-    router
-      .get('styles.css', async ({ response }) => {
-        response.type('text/css').send(style)
-      })
-      .as('styles')
-
-    router
-      .get('/', ({ response, route }) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-        const baseUrl = router.builder().params(route?.meta?.params).make(route?.pattern!)
-        response.type('text/html').send(createQueueDashHtml(baseUrl))
-      })
-      .as('index')
-
-    router
-      .get('/*', ({ response, route }) => {
-        const patternWithoutWildcard = route?.pattern.slice(0, -2)
-        const baseUrl = router.builder().params(route?.meta?.params).make(patternWithoutWildcard!)
-
-        response.type('text/html').send(createQueueDashHtml(baseUrl))
-      })
-      .as('catchAll')
-  })
+          response.type('text/html').send(createQueueDashHtml(baseUrl))
+        })
+        .as('catchAll')
+    })
+    .as('queuedash')
 }


### PR DESCRIPTION
Follow-up to #120 (now merged).

#120 added route names inside `queueDashUiRoutes()` so the returned group can be named/prefixed-and-named by consumers — fixing `RuntimeException: Routes inside a group must have names before calling "router.group.as"`. This PR polishes that work:

- **Cleaner route names.** The merged PR used `'trpc.*'` and `'*'` as route names. Wildcards and literal dots collide with AdonisJS' hierarchical route-name semantics, so they're renamed to plain identifiers: `trpc`, `main`, `styles`, `index`, `catchAll`.
- **Self-namespacing.** The returned group is named `.as('queuedash')`, so the routes are `queuedash.trpc`, `queuedash.index`, etc. by **default**. This protects consumers who mount the group with only a `.prefix()` (or no `.as()` at all) from colliding with application route names like `index` or `main`. AdonisJS prepends group names, so a consumer's own `.as('jobs')` stacks to `jobs.queuedash.*`.
- **Adds the missing changeset** (`patch` for `@nemoventures/adonis-jobs`), which #120 did not include.

No behavior change beyond route-name strings. Since #120 hasn't been released yet, there are no existing consumers of the bare names — zero migration cost to add the namespace now.

Credit to @flozdra for the original fix in #120.

### Verification
- `pnpm --filter @nemoventures/adonis-jobs typecheck` — passes
- `pnpm lint` — 0 errors (pre-existing warnings unrelated to this change)
- `pnpm format` — clean